### PR TITLE
Changed $(...).css() to match jQuery as mentioned on twitter today :)

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -37,8 +37,8 @@ var Zepto = (function() {
       return $(el && !(el===d) ? el : []);
     },
     pluck: function(property){ return this.dom.map(function(el){ return el[property] }) },
-    show: function(){ return this.css('display:block') },
-    hide: function(){ return this.css('display:none') },
+    show: function(){ return this.css('display', 'block') },
+    hide: function(){ return this.css('display', 'none') },
     prev: function(){ return $(this.pluck('previousElementSibling')) },
     next: function(){ return $(this.pluck('nextElementSibling')) },
     html: function(html){
@@ -55,8 +55,8 @@ var Zepto = (function() {
       var obj = this.dom[0].getBoundingClientRect();
       return { left: obj.left+d.body.scrollLeft, top: obj.top+d.body.scrollTop, width: obj.width, height: obj.height };
     },
-    css: function(style){
-      return this(function(el){ el.style.cssText += ';'+style });
+    css: function(prop, value){
+      return (arguments.length == 1) ? this.dom[0].style[prop] : this(function(el) { el.style[prop] = value; });
     },
     index: function(el){
       return this.dom[IO]($(el).get(0));

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -216,11 +216,16 @@
       
       testCSS: function(t){
         var el = $('#some_element').get(0);
+        $('#some_element').css('color', '#f00');
+        $('#some_element').css('border', '1px solid rgba(255,0,0,1)');
+        var style1 = $('#some_element').css('color');
+        var style2 = $('#some_element').css('border');
         
-        $('#some_element').css('color:#f00;border:1px solid rgba(255,0,0,1)');
         t.assertEqual('rgb(255, 0, 0)', el.style.color);
         t.assertEqual('rgb(255, 0, 0)', el.style.borderLeftColor);
         t.assertEqual('1px', el.style.borderLeftWidth);
+        t.assertEqual('rgb(255, 0, 0)', style1);
+        t.assertEqual('1px solid rgb(255, 0, 0)', style2);
       },
       
       testHtml: function(t){
@@ -303,7 +308,7 @@
       
       testChaining: function(t){
         t.assert(document.getElementById('nay').innerHTML == "nay");
-        $('span.nay').css('color:red').html('test');
+        $('span.nay').css('color', 'red').html('test');
         t.assert(document.getElementById('nay').innerHTML == "test");
       },
       


### PR DESCRIPTION
Hi, I have made an attempt to rewrite $(...).css() to match the jQuery interface.

It now supports get and set depending on the number of arguments...

$('#some_element').css('color', '#f00');  // returns '1px solid rgb(255, 0, 0)'
$('#some_element').css('border', '1px solid rgba(255,0,0,1)'); // sets the style value

Let me know what you think.  

Oh and also I rewrote the various tests to reflect these changes and provide coverage for the getting of a style.

Everything passes.

Cheers
Adam
