### PR TITLE
Functional test for image garbage collection

### DIFF
--- a/test/assets_functional.html
+++ b/test/assets_functional.html
@@ -4,7 +4,6 @@
   <title>Zepto assets functional test</title>
   <meta name="viewport" content="maximum-scale=1,initial-scale=1,user-scalable=0" />
   <script src="../src/zepto.js"></script>
-  <script src="../src/assets.js"></script>
   <style>
     #container div {
       margin: 2px;
@@ -23,30 +22,33 @@
   <h1>Zepto assets functional test</h1>
   
   <ul>
-    <li><a href="?without">Run without remove</a></li>
-    <li><a href="?remove">Run with remove</a></li>
+    <li><a href="?without">Run without the assets plugin</a></li>
+    <li><a href="?with">Run with the assets plugin</a></li>
     <li><a href="?">Stop</a></li>
   </ul>
   
-  <p>When running 'without remove' Mobile Safari will stop loading after on average 8 images (that's on the iPad with 1 MB images). It might also crash.</p>
+  <p>When you run this test withour the assets plugin, Mobile Safari will stop loading after on average 8 images (that's on the iPad with 1 MB images). It might also crash.</p>
   <p><strong>PLEASE NOTE:</strong> You <strong>must restart Safari</strong> between runs (click the home button to return to the home screen, double-click the home button, tap-and-hold the Safari icon, then tap the minus badge).</p>
   
   <div id="container"></div>
   
   <script>
+  <!--
     var prefix = 'http://stuff.vandervossen.net/temporary/zepto_assets_test/sintel-';
     var mode = window.location.search.slice(1);
     var timeout;
+    if (mode === 'with') {
+      document.write('<script src="../src/assets.js"></script>');
+    }
     if (mode !== '') {
       var i = 1;
       (function frame() {
-        if (mode === 'remove') {
-          $('#image' + (i - 4)).remove();
-        }
+        $('#image' + (i - 4)).remove();
         $('#container').prepend('<div>' + i + ': <img id="image' + i + '" src="' + prefix + i + '.jpg"></div>');
         if (i++ < 51) timeout = setTimeout(frame, 6000);
       })();
     }
+  -->
   </script>
 </body>
 </html>


### PR DESCRIPTION
I've updated the test to load multiple 1 MB images in sequence either with or without removing them. Can you try to replicate this and let me know if it also works for you? I’ll probably write a blog post about how this works next week.
