### PR TITLE
Updated has/addClass methods to use native classList methods. Added toggleClass method.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -92,13 +92,16 @@ var Zepto = (function() {
       $(d.body).delegate(this.selector, event, callback); return this;
     },
     hasClass: function(name){
-      return classRE(name).test(this.dom[0].className);
+      return this.dom[0].classList.contains(name);
     },
     addClass: function(name){
-      return this.each(function(el){ !$(el).hasClass(name) && (el.className += (el.className ? ' ' : '') + name) });
+      return this.each(function(el){ el.classList.add(name); el.className = el.className.trim(); });
     },
     removeClass: function(name){
       return this.each(function(el){ el.className = el.className.replace(classRE(name), ' ').trim() });
+    },
+    toggleClass: function(name){
+      return this.each(function(el){ el.classList.toggle(name); el.className = el.className.trim(); });
     },
     trigger: function(event){
       return this.each(function(el){ var e; el.dispatchEvent(e = d.createEvent('Events'), e.initEvent(event, true, false)) });

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -444,6 +444,7 @@
       
       testAddRemoveClass: function(t){
         var el = $('#some_element').get(0);
+        el.className = '';
         
         $('#some_element').addClass('green');
         t.assertEqual('green', el.className);
@@ -462,6 +463,8 @@
       
       testHasClass: function(t){
         var el = $('#some_element').get(0);
+        el.className = '';
+        
         $('#some_element').addClass('green');
         
         t.assert($('#some_element').hasClass('green'));
@@ -470,6 +473,19 @@
         $('#some_element').addClass('orange');
         t.assert($('#some_element').hasClass('green'));
         t.assert($('#some_element').hasClass('orange'));
+      },
+      
+      testToggleClass: function(t){
+        var el = $('#some_element').get(0);
+        el.className = '';
+        
+        $('#some_element').toggleClass('green');
+        
+        t.assertEqual('green', el.className);
+        
+        $('#some_element').toggleClass('green');
+        
+        t.assertEqual('', el.className);
       },
       
       testIndex: function(t){


### PR DESCRIPTION
As the commit message says, I've updated the has/addClass methods to use native `classList` methods which appear to perform better according to: http://jsperf.com/zepto-class-manipulation . I've also added a `toggleClass` method. I didn't update the `removeClass` method to use the `classList` methods as your original method seemed to perform better already.

Note: I do not know if these methods are all available on the platforms you support. I assume they would, but I don't have the means for testing on all of them.
