### PR TITLE
Modified ajax.js to fix a problem with $.post()

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,29 +1,21 @@
 (function($){
-  function ajax(method, url, success){
+  function ajax(method, url, data, success){
     var r = new XMLHttpRequest();
-    r.onreadystatechange = function(){
-      if(r.readyState==4 && (r.status==200 || r.status==0))
-        success(r.responseText);
-    };
+    r.onreadystatechange = function(){ if(r.readyState==4 && (r.status==200 || r.status==0)) success(r.responseText) };
     r.open(method,url,true);
     r.setRequestHeader('X-Requested-With','XMLHttpRequest');
-    r.send(null);
+    if (method=='POST') r.setRequestHeader('Content-Type','application/x-www-form-urlencoded');
+    r.send(data);
   }
-
-  $.get = function(url, success){ ajax('GET', url, success); };
-  $.post = function(url, success){ ajax('POST', url, success); };
-  $.getJSON = function(url, success){
-    $.get(url, function(json){ success(JSON.parse(json)) });
-  };
-  
+  $.get = function(url, success){ ajax('GET', url, null, success); };
+  $.getJSON = function(url, success){ $.get(url, function(json){ success(JSON.parse(json)) }) };
+  $.post = function(url, data, success){ ajax('POST', url, data, success); };
   $.fn.load = function(url, success){
     var self = this, parts = url.split(/\s/), selector;
     if(!this.length) return this;
     if(parts.length>1) url = parts[0], selector = parts[1];
     $.get(url, function(response){
-      self.html(selector ?
-        $(document.createElement('div')).html(response).find(selector).html()
-        : response);
+      self.html(selector ? $(document.createElement('div')).html(response).find(selector).html() : response);
       success && success();
     });
     return this;


### PR DESCRIPTION
Hi Thomas,

I found that $.post() fails when used to send data to a PHP script expecting one or more $_POST parameters.

Looking at the baseline code of ajax():
  r.open(method,url,true);
  r.setRequestHeader('X-Requested-With','XMLHttpRequest');
  r.send(null);

It's my understanding that where the r.send() call sends no data (e.g. in the case of r.send(null)), then a 'GET' request is specified regardless as to what type of request was specified in 'method'. A quick check as to whether my test php script sees a GET or POST parameter being passed from the $.post() function suggests that this is the case. i.e. as coded in v0.1.1, there is no difference between $.post and $.get ?

To fix this, I suggest adding a data parameter to $.post (which would need to be a properly formatted query string) and $.get (in which case the value is preset to null) and modifying ajax() accordingly. A 'POST' request would also need an additional request header, which I've added in. I didn't remove the current r.setRequestHeader() call though it may be unecessary in certain instances?

Of course, I could be missing something

Tim
