### PR TITLE
$.post does not allow data to be posted

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,19 +1,25 @@
 (function($){
-  function ajax(method, url, success, data){
+  function ajax(method, url, success, data, type){
     data = data || null;
-    if (data instanceof Object) data = JSON.stringify(data);
     var r = new XMLHttpRequest();
-    r.onreadystatechange = function(){
-      if(r.readyState==4 && (r.status==200 || r.status==0))
-        success(r.responseText);
-    };
+    if (success instanceof Function) {
+      r.onreadystatechange = function(){
+        if(r.readyState==4 && (r.status==200 || r.status==0))
+          success(r.responseText);
+      };
+    }
     r.open(method,url,true);
+    if (type) r.setRequestHeader("Accept", type );
+    if (data instanceof Object) data = JSON.stringify(data), r.setRequestHeader('Content-Type','application/json');
     r.setRequestHeader('X-Requested-With','XMLHttpRequest');
     r.send(data);
   }
 
   $.get = function(url, success){ ajax('GET', url, success); };
-  $.post = function(url, success, data){ ajax('POST', url, success, data); };
+  $.post = function(url, data, success, type){
+    if (data instanceof Function) type = type || success, success = data, data = null;
+    ajax('POST', url, success, data, type);
+  };
   $.getJSON = function(url, success){
     $.get(url, function(json){ success(JSON.parse(json)) });
   };

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -35,6 +35,24 @@
           });
         });
       },
+      
+      testAjaxPostWithData: function(t) {
+        t.pause();
+        $.post('fixtures/ajax_load_simple.html', { sample: 'data' }, function(response) {
+          t.resume(function() {
+            this.assert(response);
+          });
+        });
+      },
+      
+      testAjaxPostWithAcceptType: function(t) {
+        t.pause();
+        $.post('fixtures/ajax_load_simple.html', { sample: 'data' }, function(response) {
+          t.resume(function() {
+            this.assert(response);
+          });
+        }, 'text/plain');
+      },
 
       testAjaxGetJSON: function(t){
         t.pause();


### PR DESCRIPTION
This is probably an oversight...

$.post method (and $.ajax by extension) does not allow data to be sent in an XmlHttpRequest. Attached is a patch to allow both. It also transparently encoded an object into JSON string if such is used (it passes strings unmodified).

I would personally prefer $.post(url, data, success) but this would break all existing API. So instead I've done $.post(url, success, data). Please decide yourself if you feel like breaking backward compatibility or not. :)
