### PR TITLE
Support for animations in Fennec

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -2,7 +2,7 @@
   $.fn.anim = function(props, dur, ease){
     var transforms = [], opacity, k;
     for (k in props) k === 'opacity' ? opacity=props[k] : transforms.push(k+'('+props[k]+')');
-    return this.css({ '-webkit-transition': 'all '+(dur||0.5)+'s '+(ease||''),
-      '-webkit-transform': transforms.join(' '), opacity: opacity });
+    return this.css({ '-webkit-transition': 'all '+(dur||0.5)+'s '+(ease||''), '-moz-transition': 'all '+(dur||0.5)+'s '+(ease||''),
+      '-webkit-transform': transforms.join(' '), '-moz-transform': transforms.join(' '), opacity: opacity });
   }
 })(Zepto);


### PR DESCRIPTION
Looks like Fennec will support css3 animations, but obviously with the -moz vendor prefix so I updated the $.fn.anim function to add the necessary css.  Not a massive addition so shouldn't have much impact on size.
