### PR TITLE
Fail gracefully on non-webkit UAs

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -13,8 +13,7 @@
   }
   $.os = detect(navigator.userAgent);
   $.__detect = detect;
-  $.browser = {
-    webkit: true,
-    version: navigator.userAgent.match(/WebKit\/([\d.]+)/)[1]
-  }
+
+  var v = navigator.userAgent.match(/WebKit\/([\d.]+)/);
+  $.browser = v ? { webkit: true, version: v[1] } : { webkit: false };
 })(Zepto);


### PR DESCRIPTION
I understand Zepto is webkit only, but it would be nice if it didn't completely crash when loaded into a non-webkit UA. This way you can show a nice browser not supported message.

Fixes issue #50
