### PR TITLE
Add JSONP support

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -1,8 +1,26 @@
 (function($){
+
+  var jsonpID = 0;
+
   function empty() {}
+  
+  $.ajaxJSONP = function(options){
+    var jsonpString;
+    jsonpString = 'jsonp' + ++jsonpID;
+    window[jsonpString] = function(j){ options.success(j) }
+    var script = document.createElement('script');
+    $(script).attr({ src: options.url.replace(/callback=\?/, 'callback=' + jsonpString), type: 'text/javascript' });
+    $('head').append(script);
+  };
+  
   $.ajax = function(options){
     // { type, url, data, success, dataType, contentType }
     options = options || {};
+    
+    if (options.url && /callback=\?/.test(options.url)) {
+      return $.ajaxJSONP(options)
+    }
+
     var data = options.data,
         callback = options.success || empty,
         errback = options.error || empty,

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -62,6 +62,15 @@
           });
         });
       },
+      
+      testAjaxGetJSONP: function(t){
+        t.pause();
+        $.getJSON('http://api.flickr.com/services/feeds/photos_public.gne?tags=cat&tagmode=any&format=json&jsoncallback=?', function(data){
+          t.resume(function(){
+            this.assertEqual(data.items.length, 20);
+          });
+        });
+      },
 
       testAjaxLoad: function(t) {
         var testEl = $('#ajax_load');


### PR DESCRIPTION
I've pulled in deepsweet's JSONP support and merged it against the latest version of ajax.js.

We're using JSONP to talk to Twitter in our phone app that uses zepto - it'd be really nice to see this integrated in to trunk.
