### PR TITLE
Add ability to retrieve an element's computed styles

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -92,7 +92,9 @@ Context and .find calls are equivalent:
 
   anim(transform, opacity, duration):
     use -webkit-transform/opacity and do an animation
-
+  
+  getStyle('property'): gets the computed style value of a CSS property
+  
 = Utility functions:
 
   $(document).ready(function(){ ... }): call function after DOM is ready to use (before load event fires)

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -107,6 +107,9 @@ var Zepto = (function() {
       if (typeof property == 'string') css = property + ":" + value;
       return this.each(function(element) { element.style.cssText += ';' + css });
     },
+    getStyle: function(property){
+      return document.defaultView.getComputedStyle(this.dom[0], '').getPropertyValue(property);
+    },
     index: function(element){
       return this.dom.indexOf($(element).get(0));
     },

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -21,6 +21,10 @@
 
   <div id="toggle_element"></div>
 
+  <div id="get_style_wrapper" style="font-size: 16px;">
+    <div id="get_style_element" style="font-size: 3em; color: black;">Derp</div>
+  </div>
+  
   <div id="attr_1" data-id="someId1" data-name="someName1"></div>
   <div id="attr_2" data-id="someId2" data-name="someName2"></div>
 
@@ -379,6 +383,12 @@
         t.assertEqual('rgb(0, 0, 0)', $('#some_element').css('border-left-color'));
         t.assertEqual('rgb(0, 255, 0)', $('#some_element').css('color'));
         t.assertEqual('2px', $('#some_element').css('padding-left'));
+      },
+      
+      testGetStyle: function(t){
+        var div = $('#get_style_element');
+        t.assertEqual('48px', div.getStyle('font-size'));
+        t.assertEqual('rgb(0, 0, 0)', div.getStyle('color'));
       },
 
       testHtml: function(t){


### PR DESCRIPTION
I had a need for this in my project, specifically to determine the value, in pixels, of an element's font-size where the element's font-size was specified in em's and based off the value of its parent.  There are other uses, such as obtaining normalised color values.

This patch adds approximately 93 bytes to the minified distribution.
