### PR TITLE
Mimic jQuery's fn.eq() method

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -63,6 +63,7 @@ var Zepto = (function() {
     is: function(selector){
       return this.length > 0 && $(this.dom[0]).filter(selector).length > 0;
     },
+    eq: function(idx){ return $(this.get(idx)) },
     first: function(){ return $(this.get(0)) },
     last: function(){ return $(this.get(this.length - 1)) },
     find: function(selector){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -251,6 +251,19 @@
         t.assertEqual(4, index);
       },
 
+      testEq: function(t){
+        var zepto = $('h1,p'),
+            zepto2 = zepto.eq(0);
+
+        t.assertLength(5, zepto);
+        t.assertLength(1, zepto2);
+
+        t.refuteIdentical(zepto, zepto2);
+        t.assertUndefined(zepto2.tagName);
+
+        t.assertLength(0, $('nonexistent').eq(0));
+      },
+
       testFirst: function(t){
         var zepto = $('h1,p');
         t.assertLength(5, zepto);


### PR DESCRIPTION
Wrapped `$(something.get(1)).doSomething()` too many times, and being unable to chain `elements.removeClass('active').get(1).addClass('active')` was the icing on the cake.
