### PR TITLE
Basic val() method and remoteAttr() method

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -121,6 +121,9 @@ var Zepto = (function() {
           else this.setAttribute(name, value);
         });
     },
+    removeAttr: function(name) {
+      return this.each(function() { this.removeAttribute(name); });
+    },
     val: function(value){
       return (value === undefined) ?
         (this.length > 0 ? this.dom[0].value : null) :

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -676,7 +676,19 @@
         els.attr('value', '');
         t.assertEqual(els.get(0).value, els.attr('value'));
         t.assertEqual('', els.attr('value'));
+      },
 
+      testRemoveAttr: function(t) {
+        var els = $('#attr_with_text_input');
+
+        els.get(0).removeAttribute('disabled');
+        t.assertEqual(els.attr('disabled'), undefined);
+
+        els.attr('disabled', 'definitely');
+        t.assertEqual(els.attr('disabled'), 'definitely');
+        
+        els.removeAttr('disabled');
+        t.assertEqual(els.attr('disabled'), undefined);
       },
 
       testVal: function(t) {


### PR DESCRIPTION
The current attr('value') stuff only works for text fields.  The JQuery val() method is a reasonable idea, it lets you handle things which are a little weird, like the more complex form elements, in a sensible way.  (This patch doesn't do that though, but it's a place to put things like that.)

Wasn't sure whether to make the attr('value') thing always call this in the case of an input element or not.

Also added a removeAttr method.
