### PR TITLE
Handling of HTML boolean attributes

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -119,7 +119,7 @@ var Zepto = (function() {
     attr: function(name, value){
       return (typeof name == 'string' && value === undefined) ?
         (this.length > 0 && this[0].nodeName === 'INPUT' && this[0].type === 'text' && name === 'value') ? (this.val()) :
-        (this.length > 0 ? this[0].getAttribute(name) || undefined : null) :
+        (this.length > 0 ? this[0].getAttribute(name) || (name in this[0]) : null) :
         this.each(function(idx){
           if (typeof name == 'object') for (key in name) this.setAttribute(key, name[key])
           else this.setAttribute(name, typeof value == 'function' ? value(idx, this.getAttribute(name)) : value);

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -98,7 +98,10 @@
 
   <div id="namespace_test"></div>
 
+  <input type="text" id="BooleanInput" required />
+
   <script>
+
     function click(el){
       var event = document.createEvent('MouseEvents');
       event.initMouseEvent('click', true, true, document.defaultView, 1, 0, 0, 0, 0, false, false, false, false, 0, null);
@@ -916,6 +919,11 @@
         t.assertEqual($("p > span").index(".yay"), 0);
         t.assertEqual($("span").index("span"), 0);
         t.assertEqual($("span").index("boo"), -1);
+      },
+
+      testBoolAttr: function (t) {
+        t.assertEqual($('#BooleanInput').attr('required'), true);
+        t.assertEqual($('#BooleanInput').attr('non_existant_attr'), false);
       }
 
     });


### PR DESCRIPTION
Fixes issue #88

It used to return undefined as a default but now it returns true || false depending on if the attribute is present or not. Not sure if this will screw up any other functions that perhaps used "=== undefined" I've ran a few tests and things seem to check out OK.
