### PR TITLE
added $new() for element creation

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -37,7 +37,9 @@ var Zepto = (function() {
       return Z(dom, selector);
     }
   }
-
+  
+  function $new(tag) { return $(document.createElement(tag)); }
+  
   $.extend = function(target, source){ for (key in source) target[key] = source[key]; return target }
   $.qsa = $$ = function(element, selector){ return slice.call(element.querySelectorAll(selector)) }
 


### PR DESCRIPTION
I added the $new() method as a shortcut to dynamically create elements. I use is quite a lot in LITTLE, a JavaScript MVC framework I'm building for mobile WebKit devices. LITTLE is also using zepto.
