### PR TITLE
$(html) fix for multi-line HTML tags

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -13,7 +13,7 @@ var Zepto = (function() {
     return r;
   }
 
-  fragmentRE = /^\s*<.+>/;
+  fragmentRE = /^\s*<[^>]+>/;
   container = document.createElement("div");
   function fragment(html) {
     container.innerHTML = ('' + html).trim();


### PR DESCRIPTION
If you pass HTML into Zepto and the first HTML tag includes a linebreak, fragmentRE fails to recognize it (because '.' doesn't match newline by default). So the HTML fragment gets passed to qsa, producing a DOM error.

Example:
    $('<div id="myid"\ndata-item="val">')

This regex change fixes that.
