### PR TITLE
jQuery compatibility: if document is already loaded, $(document).load(function) calls the function immediately.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -79,6 +79,7 @@ var Zepto = (function() {
     indexOf: [].indexOf,
     concat: [].concat,
     ready: function(callback){
+      if (document.readyState == 'complete') callback();
       document.addEventListener('DOMContentLoaded', callback, false); return this;
     },
     get: function(idx){ return idx === undefined ? this : this[idx] },


### PR DESCRIPTION
jQuery compatibility: if document is already loaded, $(document).load(function) calls the function immediately.

Discussion: WebKit supports (since when?) document.readyState (originally an IE extension) and reports "complete" after firing DOMContentLoaded:

http://trac.webkit.org/browser/trunk/Source/WebCore/dom/Document.cpp#L1014
