### PR TITLE
Make Zepto IFrame-aware

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -4,9 +4,10 @@
 
   function empty() {}
 
-  $.ajaxJSONP = function(options){
+  $.ajaxJSONP = function(options, doc){
+    if (!doc) doc = document;
     var jsonpString = 'jsonp' + ++jsonpID,
-        script = document.createElement('script');
+        script = doc.createElement('script');
     window[jsonpString] = function(data){
       options.success(data);
       delete window[jsonpString];
@@ -91,13 +92,14 @@
   };
   $.getJSON = function(url, success){ $.ajax({ url: url, success: success, dataType: 'json' }) };
 
-  $.fn.load = function(url, success){
+  $.fn.load = function(url, success, doc){
+    if (!doc) doc = document;
     if (!this.length) return this;
     var self = this, parts = url.split(/\s/), selector;
     if (parts.length > 1) url = parts[0], selector = parts[1];
     $.get(url, function(response){
       self.html(selector ?
-        $(document.createElement('div')).html(response).find(selector).html()
+        $(doc.createElement('div')).html(response).find(selector).html()
         : response);
       success && success();
     });

--- a/src/event.js
+++ b/src/event.js
@@ -80,12 +80,13 @@
     return proxy;
   }
 
-  $.fn.delegate = function(selector, event, callback){
+  $.fn.delegate = function(selector, event, callback, doc){
+    if (!doc) doc = document;
     return this.each(function(i, element){
       add(element, event, callback, selector, function(e, data){
         var target = e.target, nodes = $$(element, selector);
         while (target && nodes.indexOf(target) < 0) target = target.parentNode;
-        if (target && !(target === element) && !(target === document)) {
+        if (target && !(target === element) && !(target === doc)) {
           callback.call(target, $.extend(createProxy(e), {
             currentTarget: target, liveFired: element
           }), data);
@@ -99,18 +100,21 @@
     });
   }
 
-  $.fn.live = function(event, callback){
-    $(document.body).delegate(this.selector, event, callback);
+  $.fn.live = function(event, callback, doc){
+    if (!doc) doc = document;
+    $(doc.body).delegate(this.selector, event, callback);
     return this;
   };
-  $.fn.die = function(event, callback){
-    $(document.body).undelegate(this.selector, event, callback);
+  $.fn.die = function(event, callback, doc){
+    if (!doc) doc = document;
+    $(doc.body).undelegate(this.selector, event, callback);
     return this;
   };
 
-  $.fn.trigger = function(event, data){
+  $.fn.trigger = function(event, data, doc){
+    if (!doc) doc = document;
     return this.each(function(){
-      var e = document.createEvent('Events');
+      var e = doc.createEvent('Events');
       e.initEvent(event, true, true)
       e.data = data;
       this.dispatchEvent(e);

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -7,10 +7,13 @@ var Zepto = (function() {
   function compact(array){ return array.filter(function(item){ return item !== undefined && item !== null }) }
   function flatten(array){ return [].concat.apply([], array); }
   function camelize(str){ return str.replace(/-+(.)?/g, function(match, chr){ return chr ? chr.toUpperCase() : '' }) }
-  function defaultDisplay(nodeName) {
+
+  function defaultDisplay(nodeName, doc) {
+    if (!doc) doc = document;
+
     if (!elemDisplay[nodeName]) {
-      var elem = document.createElement(nodeName);
-      document.body.insertAdjacentElement("beforeEnd", elem);
+      var elem = doc.createElement(nodeName);
+      doc.body.insertAdjacentElement("beforeEnd", elem);
       var display = getComputedStyle(elem, '').getPropertyValue("display");
       elem.parentNode.removeChild(elem);
       display == "none" && (display = "block");
@@ -29,8 +32,10 @@ var Zepto = (function() {
   function isA(value) { return value instanceof Array }
 
   fragmentRE = /^\s*<[^>]+>/;
-  container = document.createElement('div');
-  function fragment(html) {
+  function fragment(html, doc) {
+    if (!doc) doc = document;
+
+    container = doc.createElement('div');
     container.innerHTML = ('' + html).trim();
     var result = slice.call(container.childNodes);
     container.innerHTML = '';
@@ -44,20 +49,21 @@ var Zepto = (function() {
     return dom;
   }
 
-  function $(selector, context){
+  function $(selector, context, doc){
+    if (!doc) doc = document;
     if (!selector) return Z();
     if (context !== undefined) return $(context).find(selector);
-    else if (isF(selector)) return $(document).ready(selector);
+    else if (isF(selector)) return $(doc).ready(selector);
     else if (selector instanceof Z) return selector;
     else {
       var dom;
       if (isA(selector)) dom = compact(selector);
-      else if (selector instanceof Element || selector === window || selector === document)
+      else if (selector instanceof Element || selector === window || selector === doc)
         dom = [selector], selector = null;
       else if (fragmentRE.test(selector)) dom = fragment(selector);
       else if (selector.nodeType && selector.nodeType == 3) dom = [selector];
-      else dom = $$(document, selector);
-      return Z(dom, selector);
+      else dom = $$(doc, selector);
+      return Z(dom, selector, doc);
     }
   }
 


### PR DESCRIPTION
Hey Thomas, this is my first attempt at trying to allow selectors and other Zepto functions to access child IFrames (assuming they are in the same origin of course). This means, you can do things like:

```
var childDoc = window.zepto("#someChildIFrame")[0].contentDocument;

$("p", undefined, childDoc);
>>> Array (of paragraphs in the child IFrame)
```

I probably made at least a few mistakes - if the concept is interesting though, I can fix them up. Thanks!
