### PR TITLE
Update the ready method to fit dynamic non-blocking script load.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -84,8 +84,16 @@ var Zepto = (function() {
     indexOf: [].indexOf,
     concat: [].concat,
     ready: function(callback){
-      if (document.readyState == 'complete' || document.readyState == 'loaded') callback();
-      document.addEventListener('DOMContentLoaded', callback, false); return this;
+        if (document.readyState === "complete") {
+            callback();
+        } else {
+            document.onreadystatechange = function () {
+                if (document.readyState === "complete") {
+                    callback();
+                    document.onreadystatechange = null;
+                }
+            };
+        }
     },
     get: function(idx){ return idx === undefined ? this : this[idx] },
     size: function(){ return this.length },


### PR DESCRIPTION
If use dynamic script elements to load a script file, maybe the DOMContentLoaded event has been fired already, but the readyState is "interactive". I have no better way to know the DOMContentLoaded event whether fired, so use onreadystatechange event to check it.
