### PR TITLE
Fixes a typo in the "testLive" test.

### DIFF
--- a/test/zepto.html
+++ b/test/zepto.html
@@ -866,10 +866,10 @@
         $(document.body).append('<p class="live" id="live_this_test"></p>');
 
         $('p.live').live('click', function(){
-          t.assertEqual(document.getElementById('#live_this_test'), this);
+          t.assertEqual(document.getElementById('live_this_test'), this);
         });
         click($('#live_this_test').get(0));
-
+        
         t.assertEqual(3, counter);
       },
 


### PR DESCRIPTION
The "testLive" test from Zepto core's test suite fails because of a little typo (an #-prefixed id is supplied to document.getElementById).
The attached commit fixes this.
