### PR TITLE
Set element as context `this` on bound event handlers, with tests

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -26,7 +26,7 @@
     var id = zid(element), set = (handlers[id] || (handlers[id] = []));
     events.split(/\s/).forEach(function(event){
       var callback = delegate || fn;
-      var proxyfn = function(event) { return callback(event, event.data) };
+      var proxyfn = function(event) { return callback.call(element, event, event.data) };
       var handler = $.extend(parse(event), {fn: fn, proxy: proxyfn, sel: selector, del: delegate, i: set.length});
       set.push(handler);
       element.addEventListener(handler.e, proxyfn, false);

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -697,6 +697,19 @@
         t.assertEqual(3, counter); // 1 = body click, 2 = element click, 3 = element mousedown
       },
 
+      testBindContext: function(t){
+        var context, handler = function(){
+          context = $(this);
+        };
+        $('#empty_test').bind("click",handler);
+        $('#empty_test').bind("mousedown",handler);
+        click($('#empty_test').get(0));
+        t.assertEqualCollection($('#empty_test'), context);
+        context = null;
+        mousedown($('#empty_test').get(0));
+        t.assertEqualCollection($('#empty_test'), context);
+      },
+
       testBindWithCustomData: function(t) {
         var counter = 0;
         var handler = function(ev,customData) { counter = customData.counter };


### PR DESCRIPTION
fixes #156 and #176
