### PR TITLE
Pass event data as arguments to the handler.

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -26,7 +26,9 @@
     var id = zid(element), set = (handlers[id] || (handlers[id] = []));
     events.split(/\s/).forEach(function(event){
       var callback = delegate || fn;
-      var proxyfn = function(event) { return callback.call(element, event, event.data) };
+      var proxyfn = function(event) { 
+        return callback.apply(element, [event].concat(event.data));
+      };
       var handler = $.extend(parse(event), {fn: fn, proxy: proxyfn, sel: selector, del: delegate, i: set.length});
       set.push(handler);
       element.addEventListener(handler.e, proxyfn, false);

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1293,6 +1293,31 @@
         };
         $('#some_form').submit();
         t.assert(formSubmitted);
+      },
+
+      testCustomEvents: function (t) {
+        var $body = $(document.body);
+
+        $body.bind('custom', function(evt, a, b) {
+          t.assertEqual(a, 1);
+          t.assertEqual(b, 2);
+          $body.unbind();
+        })
+        $body.trigger('custom', [1, 2]);
+
+        $body.bind('custom', function(evt, a) {
+          t.assertEqual(a, 1);
+          $body.unbind();
+        })
+        $body.trigger('custom', 1);
+
+        var eventData = {z: 1};
+        $body.bind('custom', function(evt, a) {
+          t.assertEqual(a, eventData);
+          $body.unbind();
+        })
+        $body.trigger('custom', eventData);
+
       }
     });
   </script>


### PR DESCRIPTION
Mimic jQuery's custom event triggering syntax - http://api.jquery.com/trigger/

Allows you to write:

```
$('#foo').bind('custom', function(event, param1, param2) {
  alert(param1 + "\n" + param2);
});
$('#foo').trigger('custom', ['Custom', 'Event']);
```

Rather than:

```
$('#foo').bind('custom', function(event, params) {
  alert(params[0] + "\n" + params[1]);
});
$('#foo').trigger('custom', ['Custom', 'Event']);
```
