### PR TITLE
Updates to ReadMe

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -88,6 +88,8 @@ Context and .find calls are equivalent:
   attr('attribute', 'value'): set element attribute
   attr('attribute', function(index, oldAttr){ return ...; }): set the value of 'attribute' from a method, for each element in collection
   removeAttr('attribute'): removes an attribute
+  data('name'): gets the HTML5 data attribute value for the element. Shortcut function for $(element).attr('data-<name>')
+  data('name', 'value'): sets the HTML5 data attribute to 'value' for the element
 
   css('css property', 'value'): set a CSS property
   css({ property1: value1, property2: value2 }): set multiple CSS properties
@@ -127,8 +129,8 @@ Context and .find calls are equivalent:
 = Utility functions:
 
   $(document).ready(function(){ ... }): call function after DOM is ready to use (before load event fires)
-  $.isFunction(function), $.isObject(object), $.isArray(array): returns true if given parameter is a function; an object; or an array, respectively. 
-  $.extend(target, secondObject): extends (merge) the target object with secondObject. Modifies and returns target.
+  $.isFunction(function), $.isObject(object), $.isArray(array): returns true if given parameter is a function; an object; or an array, respectively 
+  $.extend(target, secondObject): extends (merge) the target object with secondObject. Modifies and returns target
 
 = Event handlers
 


### PR DESCRIPTION
Hi. 

While working with Zepto, I found myself scrolling through the source searching for functions more frequently than checking the Readme here at GitHub. I don't know if it's intentional, but the Readme lacks documentation on some quite interesting features. Instead of having new users of Zepto checking the unminified source code, I've added some of the missing functions with short explanations to Readme.rdoc.
