### PR TITLE
Removal of another "insertAdjacentElement" to fix zepto in FF

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -25,7 +25,7 @@ var Zepto = (function() {
     var element, display;
     if (!elementDisplay[nodeName]) {
       element = document.createElement(nodeName);
-      document.body.insertAdjacentElement("beforeEnd", element);
+      document.body.appendChild(element);
       display = getComputedStyle(element, '').getPropertyValue("display");
       element.parentNode.removeChild(element);
       display == "none" && (display = "block");


### PR DESCRIPTION
This was already done before (in pcwalton/zepto@f23bcd0dfc9f70d8a0d0), but another "insertAdjacentElement" was added since then, breaking FF compatibilty. This commit should fix it again.
