### PR TITLE
One event binder callback now receives events in callback

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -57,8 +57,8 @@
   $.fn.one = function(event, callback){
     return this.each(function(){
       var self = this;
-      add(this, event, function wrapper(){
-        callback();
+      add(this, event, function wrapper(evt){
+        callback(evt);
         remove(self, event, arguments.callee);
       });
     });

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -953,6 +953,13 @@
         t.assertEqual(1, counter);
       },
 
+      testOneCallbackEvent: function(t){
+        var target, someElement = $('#some_element').get(0);
+        $(document.body).one('click', function(evt){ target = evt.target; });
+        click(someElement);
+        t.assertEqual(someElement, target);
+      },
+
       testAttr: function(t){
         var els = $('#attr_1, #attr_2');
 


### PR DESCRIPTION
Previously, when binding events using the 'one' binder, the callback event didn't receive the event as an argument. This tiny fix changes that.
