### PR TITLE
fix .one() did not have the element as context `this` -- with tests

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -58,7 +58,7 @@
     return this.each(function(){
       var self = this;
       add(this, event, function wrapper(evt){
-        callback(evt);
+        callback.call(self, evt);
         remove(self, event, arguments.callee);
       });
     });

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -954,10 +954,11 @@
       },
 
       testOneCallbackEvent: function(t){
-        var target, someElement = $('#some_element').get(0);
-        $(document.body).one('click', function(evt){ target = evt.target; });
+        var target, context, someElement = $('#some_element').get(0);
+        $(document.body).one('click', function(evt){ target = evt.target; context = $(this); });
         click(someElement);
         t.assertEqual(someElement, target);
+        t.assertEqualCollection($(document.body), context);
       },
 
       testAttr: function(t){


### PR DESCRIPTION
The last commit brought this to my attention. 
.one() should have the calling element as it's context, similar to .bind()
