### PR TITLE
end() support

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -102,6 +102,9 @@ var Zepto = (function() {
         return $$(element.parentNode, selector).indexOf(element) >= 0;
       }));
     },
+    end: function(){
+      return this.prevObject || $();
+    },
     add:function(selector,context){
       return $(uniq(this.concat($(selector,context))));
     },
@@ -299,6 +302,15 @@ var Zepto = (function() {
       });
     }
   };
+
+  'filter,add,not,eq,first,last,find,closest,parents,parent,children,siblings'.split(',').forEach(function(property){
+    var fn = $.fn[property];
+    $.fn[property] = function() {
+      var ret = fn.apply(this, arguments);
+      ret.prevObject = this;
+      return ret;
+    }
+  });
 
   ['width', 'height'].forEach(function(property){
     $.fn[property] = function(){ var offset = this.offset(); return offset ? offset[property] : null }

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -162,6 +162,11 @@
     <div class="unwrap_two"><b><span>1</span><span>2</span></b></div>
   </div>
 
+  <div id="end_test">
+    <div class="end_one"><b><span></span></b></div>
+    <div class="end_two"><b><span>1</span><span>2</span></b></div>
+  </div>
+
   <script>
 
     function click(el){
@@ -1293,6 +1298,15 @@
         };
         $('#some_form').submit();
         t.assert(formSubmitted);
+      },
+
+      testEnd: function (t) {
+        t.assert($().end().length, 0);
+
+        var $endTest = $('#end_test');
+        var $endTest2 = $('#end_test').find('div').find('span').end().end();
+        t.assertEqual($endTest.length, $endTest2.length);
+        t.assertEqual($endTest.get(0), $endTest2.get(0));
       }
     });
   </script>


### PR DESCRIPTION
Add end() support to Zepto by wrapping methods that change the working elements.
