### PR TITLE
Extend extend. Useful for plugins patterns: var opts = $.extend({}, defa

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -64,7 +64,12 @@ var Zepto = (function() {
     }
   }
 
-  $.extend = function(target, source){ for (key in source) target[key] = source[key]; return target }
+  $.extend = function(target){ 
+    slice.call(arguments, 1).forEach(function(source) {
+      for (key in source) target[key] = source[key];
+    })
+    return target;
+  }
   $.qsa = $$ = function(element, selector){ return slice.call(element.querySelectorAll(selector)) }
 
   function filtered(nodes, selector){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -241,6 +241,10 @@
         var obj = {};
         t.assertIdentical(obj, $.extend(obj, {a: 1}));
         t.assertEqual(1, obj.a);
+
+        obj = {};
+        t.assertIdentical(obj, $.extend(obj, {a: 1}, {b: 2}))
+        t.assertEqual(2, obj.b);
       },
 
       testDollar: function(t){


### PR DESCRIPTION
Extend extend. Useful for plugins patterns: var opts = $.extend({}, default, argOptions)
