### PR TITLE
.index() w/ no arg returns position of first element relative siblings

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -262,7 +262,7 @@ var Zepto = (function() {
       return this.each(function() { this.style.cssText += ';' + css });
     },
     index: function(element){
-      return this.indexOf($(element)[0]);
+      return element ? this.indexOf($(element)[0]) : this.parent().children().indexOf(this[0]);
     },
     hasClass: function(name){
       return classRE(name).test(this[0].className);

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -174,6 +174,11 @@
     <div class="eq2"></div>
   </div>
 
+  <div id="index_test">
+    <div class="index0"></div>
+    <div class="index1"></div>
+  </div>
+
   <script>
 
     function click(el){
@@ -1291,6 +1296,8 @@
         t.assertEqual($("p > span").index(".yay"), 0);
         t.assertEqual($("span").index("span"), 0);
         t.assertEqual($("span").index("boo"), -1);
+
+        t.assertEqual($('#index_test > *').eq(-1).index(), 1);
       },
 
       testBoolAttr: function (t) {


### PR DESCRIPTION
If no argument is passed to the .index() method, the return value is an integer indicating the position of the first element within the Zepto object relative to its sibling elements.
