### PR TITLE
Provide support for array serialization without brackets

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -107,19 +107,32 @@
     return this;
   };
 
-  $.param = function(obj, v){
-    var result = [], add = function(key, value){
-      result.push(encodeURIComponent(v ? v + '[' + key + ']' : key)
-        + '=' + encodeURIComponent(value));
+  $.param = function(obj, v, traditional){
+    var objLength, result = [], add = function(key, value){
+      var name;
+      if (!traditional) {
+        name = v ? v + '[' + key + ']' : key;
+      } else {
+        name = key;
+      }
+      result.push(encodeURIComponent(name) + '=' + encodeURIComponent(value));
       },
       isObjArray = $.isArray(obj);
 
-    for(key in obj)
-      if(isObject(obj[key]))
-        result.push($.param(obj[key], (v ? v + '[' + key + ']' : key)));
-      else
-        add(isObjArray ? '' : key, obj[key]);
-
+    if (isObjArray && traditional) {
+      objLength = obj.length;
+      for (var i = 0; i < objLength; i++) {
+        add(key, obj[i]);
+      }
+    } else {
+      for(key in obj) {
+        if(isObject(obj[key])) {
+          result.push($.param(obj[key], (v ? v + '[' + key + ']' : key), traditional));
+        } else {
+          add(isObjArray ? '' : key, obj[key]);
+        }
+      }
+    }
     return result.join('&').replace('%20', '+');
   };
 })(Zepto);

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -338,6 +338,10 @@
         result = decodeURIComponent(result);
         t.assertEqual(result, "libs[]=jQuery&libs[]=script.aculo.us&libs[]=Prototype&libs[]=Dojo");
 
+        result = $.param({ libs: ['jQuery', 'script.aculo.us', 'Prototype', 'Dojo'] }, null, true);
+        result = decodeURIComponent(result);
+        t.assertEqual(result, "libs=jQuery&libs=script.aculo.us&libs=Prototype&libs=Dojo");
+
         result = $.param({ jquery: 'Javascript', rails: 'Ruby', django: 'Python' });
         result = decodeURIComponent(result);
         t.assertEqual(result, "jquery=Javascript&rails=Ruby&django=Python");


### PR DESCRIPTION
Little patch + test to allow for using Zepto.param() with backends that don't support `key[]` formatted seriialization of array values.  Could be big holes in the implementation. The assumption is that any recursion beyond one level deep is not going to happen since there's no sane way to serialize nested data w/out the brackets.
