### PR TITLE
Use textContent instead of innerText to support FF

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -72,7 +72,7 @@ Context and .find calls are equivalent:
   html(function(index, oldhtml){ return ...; }): set the contents of the element(s) from a method
 
   html(): get first element's .innerHTML
-  text(): get first element's .innerText
+  text(): get first element's .textContent
   text('new text'): set the text contents of the element(s)
   append(), prepend(): like html(), but add html (or a DOM Element or a Zepto object) to element contents
   before(), after(): add html (or a DOM Element or a Zepto object) before/after the element

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -218,8 +218,8 @@ var Zepto = (function() {
     },
     text: function(text){
       return text === undefined ?
-        (this.length > 0 ? this[0].innerText : null) :
-        this.each(function(){ this.innerText = text });
+        (this.length > 0 ? this[0].textContent : null) :
+        this.each(function(){ this.textContent = text });
     },
     attr: function(name, value){
       return (typeof name == 'string' && value === undefined) ?


### PR DESCRIPTION
Replace .text() method to use `textContent` instead of `innerText` to support Firefox
