### PR TITLE
Fixes failures creating fragments of types thead, tfoot - more flexible containers

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -5,12 +5,20 @@ var Zepto = (function() {
     elementDisplay = {}, classCache = {},
     getComputedStyle = document.defaultView.getComputedStyle,
     fragmentRE = /^\s*<[^>]+>/,
+	containerEls = {
+	  'table': document.createElement('table'),
+	  'tbody': document.createElement('tbody'),
+	  'tr': document.createElement('tr'),
+	  'div': document.createElement('div')
+	},
     containers = {
-	  'tbody': document.createElement('table'),
-	  'tr': document.createElement('tbody'),
-	  'th': document.createElement('tr'),
-	  'td': document.createElement('tr'),
-	  'other': document.createElement('div')
+	  'thead': 'table',
+	  'tbody': 'table',
+	  'tfoot': 'table',
+	  'tr': 'tbody',
+	  'th': 'tr',
+	  'td': 'tr',
+	  'other': 'div'
 	};
 
   function isF(value) { return ({}).toString.call(value) == "[object Function]" }
@@ -44,9 +52,10 @@ var Zepto = (function() {
 	var fragmentTypeRE = /<(\w*)/g,
 		match = fragmentTypeRE.exec(html.trim()),
 		type = (match && match[1]) ? match[1] : 'other',
-		container = containers[type] || containers.other;
-    container.innerHTML = ('' + html).trim();
-    return slice.call(container.childNodes);
+		container = containers[type] || containers.other,
+		el = containerEls[container];
+    el.innerHTML = ('' + html).trim();
+    return slice.call(el.childNodes);
   }
 
   function Z(dom, selector){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1331,6 +1331,18 @@
         el = $('<td></td>');
         t.assertEqual(el.size(), 1);
         t.assertEqual(typeof el.get(0), 'object');
+        el = $('<tr></tr>');
+        t.assertEqual(el.size(), 1);
+        t.assertEqual(typeof el.get(0), 'object');
+        el = $('<thead></thead>');
+        t.assertEqual(el.size(), 1);
+        t.assertEqual(typeof el.get(0), 'object');
+        el = $('<tbody></tbody>');
+        t.assertEqual(el.size(), 1);
+        t.assertEqual(typeof el.get(0), 'object');
+        el = $('<tfoot></tfoot>');
+        t.assertEqual(el.size(), 1);
+        t.assertEqual(typeof el.get(0), 'object');
       }
     });
   </script>


### PR DESCRIPTION
Using zepto right now to generate tables on the iPhone, which is why I'm running into these issues.

I'm not a DOM rules expert, so I don't have a complete list of all the node types webkit will refuse to insert into a <div>, but this solution is generic enough to allow quite trivial updates when further elements are found to be un-create-able.
