### PR TITLE
trim whitespace from html fragment when using $("<xxx>...</xxx>") to create dom element

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -84,7 +84,7 @@ var Zepto = (function() {
       else if (elementTypes.indexOf(selector.nodeType) >= 0 || selector === window)
         dom = [selector], selector = null;
       else if (fragmentRE.test(selector))
-        dom = fragment(selector, RegExp.$1), selector = null;
+        dom = fragment(selector.trim(), RegExp.$1), selector = null;
       else if (selector.nodeType && selector.nodeType == 3) dom = [selector];
       else dom = $$(document, selector);
       return Z(dom, selector);

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -369,6 +369,9 @@
         t.assertEqual(Node.TEXT_NODE, fragment.get(1).nodeType);
         t.assertEqual("<span>world</span>", outerHTML(fragment.get(2)));
         t.assertEqual('', fragment.selector);
+
+        fragment = $("<div>hello</div> ");
+        t.assertLength(1, fragment);
       },
 
       testDollarWithTextNode: function(t){


### PR DESCRIPTION
jQuery ignores whitespace surrounding an html fragment when using $("<xxx>...</xxx>") to create dom elements.  This patch trims the html fragment input.  We do not preform the trim in the function "fragment" because that would break "append, prepend etc" which are white space sensitive and also use function "fragment".

Before patch

```
fragment = $("<div>hello</div> ");  // notice space after </div>
```

would return an array with two elements, the div and a text node.
now it returns an array with one element, the div.
