### PR TITLE
Handle JSON requests that return a single space

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -150,7 +150,7 @@
       if (xhr.readyState == 4) {
         var result, error = false;
         if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 0) {
-          if (mime == 'application/json' && !(xhr.responseText == '')) {
+          if (mime == 'application/json' && !(xhr.responseText == '' || xhr.responseText == ' ')) {
             try { result = JSON.parse(xhr.responseText); }
             catch (e) { error = e; }
           }

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -229,6 +229,24 @@
         t.assertEqual("world", result.hello);
       },
 
+      testJSONResponseBodiesAreNotParsedWhenDataTypeOptionIsJSONButResponseIsEmptyString: function(t) {
+        var result = {};
+        var success = false;
+        $.ajax({ dataType: 'json', success: function(json) {result = json; success = true } });
+        MockXHR.last.ready(4, 200, '');
+        t.assert(success);
+        t.assertEqual('', result);
+      },
+
+      testJSONResponseBodiesAreNotParsedWhenDataTypeOptionIsJSONButResponseIsSingleSpace: function(t) {
+        var result = {};
+        var success = false;
+        $.ajax({ dataType: 'json', success: function(json) {result = json; success = true } });
+        MockXHR.last.ready(4, 200, ' ');
+        t.assert(success);
+        t.assertEqual(' ', result);
+      },
+
       testDataOptionIsConvertedToSerializedForm: function(t) {
         $.ajax({ data: {hello: 'world', array: [1,2,3], object: { prop1: 'val', prop2: 2 } } });
 		MockXHR.last.data = decodeURIComponent(MockXHR.last.data);


### PR DESCRIPTION
In Rails, specifying "head :ok" or "render => :nothing" returns a single space instead of an empty string in the response body.  This commit checks xhr.responseText against the single space case.  Tests included!
