### PR TITLE
When there's a tap the swipe event is fired on Nokia Symbian and Playbook devices.

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -44,7 +44,7 @@
         $(touch.target).trigger('doubleTap');
         touch = {};
       } else if ( (touch.x2 && Math.abs(touch.x1 - touch.x2) > 30) ||
-                  (touch.y2 && Math.abs(touch.y1 - touch.y2) > 30) ) {           
+                  (touch.y2 && Math.abs(touch.y1 - touch.y2) > 30) ) {          
         $(touch.target).trigger('swipe') &&
         $(touch.target).trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)));
         touch.x1 = touch.x2 = touch.y1 = touch.y2 = touch.last = 0;


### PR DESCRIPTION
When there's a tap, the swipe event is fired on Nokia Symbian and Playbook tablet devices (this should not be the case since this is just a tap and not a swipe).

It seems that there is a slight move when tap event is fired on these devices, so touch.x2 and touch.y2 get set.  But because the delta comparison Math.abs(touch.x1 - touch.x2) > 30) and Math.abs(touch.y1 - touch.y2) > 30) are inside the conditional block that checks if touch.x2 or touch.y2 > 0, the last conditional "else if ('last' in touch)" is never reached.  Moving the delta comparison in the conditional check fixes this issue.

This has been tested on Playbook, Nokia Symbian, iPad and iPhone devices.
