### PR TITLE
The Lonely Request a.k.a The AJAX Timeout Model

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -141,13 +141,14 @@
     }
 
     var mime = settings.accepts[settings.dataType],
-        xhr = $.ajaxSettings.xhr();
+        xhr = $.ajaxSettings.xhr(), timeoutID;
 
     settings.headers = $.extend({'X-Requested-With': 'XMLHttpRequest'}, settings.headers || {});
     if (mime) settings.headers['Accept'] = mime;
 
     xhr.onreadystatechange = function(){
       if (xhr.readyState == 4) {
+        clearTimeout(timeoutID);
         var result, error = false;
         if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 0) {
           if (mime == 'application/json' && !(/^\s*$/.test(xhr.responseText))) {
@@ -187,7 +188,7 @@
     };
 
     if (settings.timeout > 0) {
-      setTimeout(handleTimeout, settings.timeout);
+      timeoutID = setTimeout(handleTimeout, settings.timeout);
     }
     if (sendRequest() === false) {
       return false;


### PR DESCRIPTION
From http://positionabsolute.net/blog/2008/07/prototype-ajax-request-timeout.php

"In the programming model of a client receiving data from an HTTP source is the always present request and response model. This stays true when employing the technique of Ajax as well but just in typically smaller packages. There are instances where the client simply won't receive a response. In a typical HTTP request the browser will timeout and the user will be notified of the error and can take action to try again or go elsewhere. When using an XHR, the heart and soul of Ajax, the request can linger indefinitey without proper precautions. The XHR does have an abort method but has no internal timeout functionality."

Related issues:
https://github.com/madrobby/zepto/issues/209
https://github.com/madrobby/zepto/issues/253
