### PR TITLE
Performance tweak in $.ajax

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -146,7 +146,7 @@
     if (settings.data && !settings.contentType) settings.contentType = 'application/x-www-form-urlencoded';
     if (isObject(settings.data)) settings.data = $.param(settings.data);
 
-    if (settings.type.match(/get/i) && settings.data) {
+    if (settings.type.toLowerCase() === "get" && settings.data) {
       var queryString = settings.data;
       if (settings.url.match(/\?.*=/)) {
         queryString = '&' + queryString;


### PR DESCRIPTION
Changed from regexp to use of toLowerCase since that seems to be faster:
http://jsperf.com/caseinsensetive-string-comparison
