### PR TITLE
$(el).toggleClass("foo", true) should _always_ add the class.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -377,8 +377,8 @@ var Zepto = (function() {
     toggleClass: function(name, when){
       return this.each(function(idx){
        var cls = this.className, newName = funcArg(this, name, idx, cls);
-       ((when !== undefined && !when) || $(this).hasClass(newName)) ?
-         $(this).removeClass(newName) : $(this).addClass(newName)
+       (when == undefined ? !$(this).hasClass(newName) : when) ?
+        $(this).addClass(newName) : $(this).removeClass(newName);
       });
     }
   };

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1653,6 +1653,12 @@
         $('#toggle_element').toggleClass('orange', false);
         t.assert(!$('#toggle_element').hasClass('orange'));
 
+        $('#toggle_element').toggleClass('orange', false);
+        t.assert(!$('#toggle_element').hasClass('orange'));
+
+        $('#toggle_element').toggleClass('orange', true);
+        t.assert($('#toggle_element').hasClass('orange'));
+
         $('#toggle_element').toggleClass('orange', true);
         t.assert($('#toggle_element').hasClass('orange'));
 


### PR DESCRIPTION
The 'switch' parameter does not indicate whether to toggle the class
(which would be pretty useless): rather, it indicates whether the class
should be added or removed. The jQuery documentation is a little bit
ambiguous on this point, but a close reading of the source and some
behavioural tests show this second interpretation to be correct, and
Zepto should be updated to conform to the jQuery interface ("all APIs
provided match their jQuery counterparts").

The tests were passing because they did not test the cases where the
element had the class and toggleClass was called with switch=true,
or the element did not have the class and switch=false. I've added
these cases into the test suite.
