### PR TITLE
Fix: Support insertion of CharacterData nodes

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -436,7 +436,7 @@ var Zepto = (function() {
   adjacencyOperators.forEach(function(key, operator) {
     $.fn[key] = function(html){
       var nodes = isO(html) ? html : fragment(html);
-      if (!('length' in nodes)) nodes = [nodes];
+      if (!('length' in nodes) || nodes.nodeType) nodes = [nodes];
       if (nodes.length < 1) return this;
       var size = this.length, copyByClone = size > 1, inReverse = operator < 2;
 

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1114,6 +1114,20 @@
 
         t.assertEqual('before<div id="beforeafter">prependappend</div>after', $('#beforeafter_container').html());
 
+        //testing with TextNode as parameter
+        $('#beforeafter_container').html('<div id="beforeafter"></div>');
+
+        function text(contents){
+          return document.createTextNode(contents);
+        }
+
+        $('#beforeafter').append(text('append'));
+        $('#beforeafter').prepend(text('prepend'));
+        $('#beforeafter').before(text('before'));
+        $('#beforeafter').after(text('after'));
+
+        t.assertEqual('before<div id="beforeafter">prependappend</div>after', $('#beforeafter_container').html());
+
         $('#beforeafter_container').html('<div id="beforeafter"></div>');
 
         function div(contents){


### PR DESCRIPTION
The original test for arrays yields false positives, since CharacterData elements also have a length property. Hence $('body').append(document.createTextNode('foo')) throws a TypeError.
