### PR TITLE
Support withCredentials for Cross-Origin Resource Sharing

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -254,6 +254,8 @@
     };
 
     xhr.open(settings.type, settings.url, true);
+    
+    if (settings.withCredentials) xhr.withCredentials = true;
 
     if (settings.contentType) settings.headers['Content-Type'] = settings.contentType;
     for (name in settings.headers) xhr.setRequestHeader(name, settings.headers[name]);


### PR DESCRIPTION
Without this flag, cookies are not included on CORS requests.
