### PR TITLE
JSONP Band-aid

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -98,6 +98,8 @@
         ajaxComplete(xhr, options, 'abort');
       },
       xhr = { abort: abort }, abortTimeout;
+      
+    for (key in $.ajaxSettings) if (options[key] === undefined) options[key] = $.ajaxSettings[key];
 
     window[callbackName] = function(data){
       clearTimeout(abortTimeout);


### PR DESCRIPTION
I just modified $.ajaxJSONP to use $.ajaxSettings' attributes as the defaults for the options argument the same way that $.ajax does. This prevented an error when the options object was not completely defined (ie. when options.complete is undefined).
