### PR TITLE
css(property,'') should remove the style as in jquery

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -354,11 +354,16 @@ var Zepto = (function() {
       var css = '';
       for (key in property) {
         if(typeof property[key] == 'string' && property[key] == '')
-          this[0].style.removeProperty(dasherize(key));
+          this.each(function() {this.style.removeProperty(dasherize(key))});
         else
           css += dasherize(key) + ':' + maybeAddPx(key, property[key]) + ';';
       }
-      if (typeof property == 'string') css = dasherize(property) + ":" + maybeAddPx(property, value);
+      if (typeof property == 'string') {
+        if (value == '')
+          this.each(function() {this.style.removeProperty(dasherize(property))});
+        else
+          css = dasherize(property) + ":" + maybeAddPx(property, value);
+      }
       return this.each(function() { this.style.cssText += ';' + css });
     },
     index: function(element){


### PR DESCRIPTION
Both invocation styles are supported :

css('position','')  // removes position style
css({position:'', top:''}) // removes both position and top styles

Here is the quote from  relevant part of jquery docs http://api.jquery.com/css/

> When using .css() as a setter, jQuery modifies the element's style property. For example, $('#mydiv').css('color', 'green') is equivalent to document.getElementById('mydiv').style.color = 'green'.  Setting the value of a style property to an empty string — e.g. $('#mydiv').css('color', '') — removes that property from an element if it has already been directly applied, whether in the HTML style attribute, through jQuery's .css() method, or through direct DOM manipulation of the style property. It does not, however, remove a style that has been applied with a CSS rule in a stylesheet or <style> element.
