### PR TITLE
Removed the "you need to include touch.js"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 
-
 # Zepto.js: a minimalist framework for mobile WebKit browsers
 
 Zepto.js is a minimalist framework for mobile WebKit browsers,
@@ -201,8 +200,7 @@ $('some selector').unbind();
 
 # Touch events
 
-Zepto has several extensions over the jQuery API to make it easy to react to touch events.
-You need to include touch.js and/or gesture.js to use these.
+Zepto has several extensions over the jQuery API to make it easy to react to touch events. 
 
 Tapping:
 


### PR DESCRIPTION
... the default download, and I spent an hour trying to debug the errors that happen when its included twice. (Alternatively, the code should be amended so that adding twice won't matter?)
