### PR TITLE
Correct ajaxComplete argument order for JSONP abort and timeout.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -95,7 +95,7 @@
       abort = function(){
         $(script).remove();
         if (callbackName in window) window[callbackName] = empty;
-        ajaxComplete(xhr, options, 'abort');
+        ajaxComplete('abort', xhr, options);
       },
       xhr = { abort: abort }, abortTimeout;
 
@@ -111,7 +111,7 @@
 
     if (options.timeout > 0) abortTimeout = setTimeout(function(){
         xhr.abort();
-        ajaxComplete(xhr, options, 'timeout');
+        ajaxComplete('timeout', xhr, options);
       }, options.timeout);
 
     return xhr;


### PR DESCRIPTION
The calls to `ajaxComplete` from within `ajaxJSONP` currently have incorrectly ordered arguments. This results in the callbacks never being triggered when abort is called or a timeout occurs.
