### PR TITLE
Add AMD to Zepto

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -468,3 +468,7 @@ var Zepto = (function() {
 
 window.Zepto = Zepto;
 '$' in window || (window.$ = Zepto);
+
+if ( typeof define === "function" && define.amd ) {
+  define( "zepto", [], function () { return Zepto; } );
+}


### PR DESCRIPTION
Very usefull, when we want to choose between Jquery or Zepto on the client side: 

```
define.amd.jQuery = true;

define([
  RegExp(" AppleWebKit/").test(navigator.userAgent)? 'zepto' : 'jquery'
], function($){
  $(function(){
    $('#main').text('Hello World !!!');
  });
});
```
