### PR TITLE
Modification to tap behavior

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -21,7 +21,7 @@
   var longTapDelay = 750;
   function longTap(){
     if (touch.last && (Date.now() - touch.last >= longTapDelay)) {
-      $(touch.target).trigger('longTap');
+      touch.el.trigger('longTap');
       touch = {};
     }
   }
@@ -29,7 +29,7 @@
   $(document).ready(function(){
     $(document.body).bind('touchstart', function(e){
       var now = Date.now(), delta = now - (touch.last || now);
-      touch.target = parentIfText(e.touches[0].target);
+      touch.el = $(parentIfText(e.touches[0].target));
       touchTimeout && clearTimeout(touchTimeout);
       touch.x1 = e.touches[0].pageX;
       touch.y1 = e.touches[0].pageY;
@@ -41,24 +41,26 @@
       touch.y2 = e.touches[0].pageY;
     }).bind('touchend', function(e){
       if (touch.isDoubleTap) {
-        $(touch.target).trigger('doubleTap');
+        touch.el.trigger('doubleTap');
         touch = {};
       } else if (touch.x2 > 0 || touch.y2 > 0) {
         (Math.abs(touch.x1 - touch.x2) > 30 || Math.abs(touch.y1 - touch.y2) > 30)  &&
-          $(touch.target).trigger('swipe') &&
-          $(touch.target).trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)));
+          touch.el.trigger('swipe') &&
+          touch.el.trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)));
         touch.x1 = touch.x2 = touch.y1 = touch.y2 = touch.last = 0;
       } else if ('last' in touch) {
+        touch.el.trigger('tap');
+
         touchTimeout = setTimeout(function(){
           touchTimeout = null;
-          $(touch.target).trigger('tap')
+          touch.el.trigger('singleTap');
           touch = {};
         }, 250);
       }
     }).bind('touchcancel', function(){ touch = {} });
   });
 
-  ['swipe', 'swipeLeft', 'swipeRight', 'swipeUp', 'swipeDown', 'doubleTap', 'tap', 'longTap'].forEach(function(m){
+  ['swipe', 'swipeLeft', 'swipeRight', 'swipeUp', 'swipeDown', 'doubleTap', 'tap', 'singleTap', 'longTap'].forEach(function(m){
     $.fn[m] = function(callback){ return this.bind(m, callback) }
   });
 })(Zepto);

--- a/test/touch_functional.html
+++ b/test/touch_functional.html
@@ -46,6 +46,9 @@
       })
       .longTap(function(){
         $(this).append(' | long tap!');
+      })
+      .singleTap(function(){
+        $(this).append(' | single tap!');
       });
   </script>
 </body>


### PR DESCRIPTION
Allows devs to use either "tap" or "singleTap," depending on whether they want to use the 250ms "buffer" for a doubleTap. Greatly improves perceived response/performance for apps that aren't using doubleTap (most, I would think).

Also cache the element for performance, and avoid the target keyword.
