### PR TITLE
zepto.js

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -411,7 +411,7 @@ var Zepto = (function() {
     }
   };
 
-  'filter,add,not,eq,first,last,find,closest,parents,parent,children,siblings'.split(',').forEach(function(property){
+  'filter,add,not,eq,first,last,find,closest,parents,parent,children,siblings,clone'.split(',').forEach(function(property){
     var fn = $.fn[property];
     $.fn[property] = function() {
       var ret = fn.apply(this, arguments);


### PR DESCRIPTION
Fix:
.css() converted any string into something like "0:b,1:a,2:c,3:k (...)" when calling .css() like ('background-color', 'black'). That happened because it created a for-in loop no matter what.

New:
.css() now removes css properties from the cssText when passed in empty.

New:
added a basic .clone() implementation.
