### PR TITLE
Have empty values in `css()` remove CSS properties

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -45,6 +45,10 @@ var Zepto = (function() {
     return name in classCache ?
       classCache[name] : (classCache[name] = new RegExp('(^|\\s)' + name + '(\\s|$)'));
   }
+  
+  function removeCSSProperty(style, name){
+    style.cssText = style.cssText.replace( RegExp( dasherize(name) + ':\\s*.*?;\\s*', 'g' ), '' );
+  }
 
   function maybeAddPx(name, value) { return (typeof value == "number" && !cssNumber[dasherize(name)]) ? value + "px" : value; }
 
@@ -352,8 +356,18 @@ var Zepto = (function() {
         );
       }
       var css = '';
-      for (key in property) css += dasherize(key) + ':' + maybeAddPx(key, property[key]) + ';';
-      if (typeof property == 'string') css = dasherize(property) + ":" + maybeAddPx(property, value);
+      if (typeof property == 'object')
+        for (key in property) {
+          if(property[key].length)
+            css += dasherize(key) + ':' + maybeAddPx(key, property[key]) + ';';
+          else
+            this.each(function() { removeCSSProperty(this.style, key); });
+        }
+      else if (typeof property == 'string')
+        if(value.length)
+          css = dasherize(property) + ":" + maybeAddPx(property, value);
+        else
+          this.each(function() { removeCSSProperty(this.style, property); });
       return this.each(function() { this.style.cssText += ';' + css });
     },
     index: function(element){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -957,6 +957,12 @@
         var div = $('#get_style_element');
         t.assertEqual('48px', div.css('font-size'));
         t.assertEqual('rgb(0, 0, 0)', div.css('color'));
+        
+        $('#some_element').css({
+          'background-color': ''
+        });
+        
+        t.assertEqual('', el.style.backgroundColor);
       },
 
       testCSSOnNonExistElm: function (t) {


### PR DESCRIPTION
Fix:
.css() now only uses a for-in loop on property names if 'property' is actually an object. It created a "css" variable of 0:'b',1:'a', 2:'c', 3:'k' everytime a string/value pair was passed in so far.

New:
.css() will now remove the css property entirely from the cssText when its corresponding value is empty.
