### PR TITLE
Correct misleading instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In short, Zepto is expected to work in every modern browser except Internet Expl
 Basic call with CSS selector:
 
 ``` js
-$('p>span').html('yoho').css('color:red');
+$('p>span').html('yoho').css({color: 'red'});
 ```
 
 Instead of a selector, a DOM Element, or a list of nodes can be passed in.
@@ -42,7 +42,7 @@ The $ function takes an optional context argument, which can be a DOM Element or
 $('span', $('p'))  // -> find all <span> elements in <p> elements
 
 $('p').bind('click', function(){
-  $('span', this).css('color:red'); // affects "span" children/grandchildren
+  $('span', this).css({color: 'red'}); // affects "span" children/grandchildren
 });
 ```
 


### PR DESCRIPTION
The first 2 examples of the "Syntax & features" section of the README use an invalid syntax like :

``` javascript
.css('color:red');
```

Instead of using :

``` javascript
.css({color: 'red'});
```

or

``` javascript
.css('color', 'red');
```

I don't know wich syntax should be the de facto standard in the docs. I personally prefer using ({color: 'red'}) over ('color', 'red'), but I guess that can be debated. 
