### PR TITLE
This commit adds scroll suppression from jQuery Mobile

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -39,11 +39,15 @@
     }).bind('touchmove', function(e){
       touch.x2 = e.touches[0].pageX;
       touch.y2 = e.touches[0].pageY;
+      if( Math.abs(touch.x1 - touch.x2 ) > 10) {
+        e.preventDefault();
+      }
     }).bind('touchend', function(e){
       if (touch.isDoubleTap) {
         touch.el.trigger('doubleTap');
         touch = {};
       } else if (touch.x2 > 0 || touch.y2 > 0) {
+        ((Date.now() - touch.last < 1000) && (Math.abs(touch.x1 - touch.x2) > 30) && (Math.abs(touch.y1 - touch.y2) < 75)) &&
         (Math.abs(touch.x1 - touch.x2) > 30 || Math.abs(touch.y1 - touch.y2) > 30)  &&
           touch.el.trigger('swipe') &&
           touch.el.trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)));


### PR DESCRIPTION
This commit adds scroll suppression from jQuery Mobile as detailed here: http://code.jquery.com/mobile/latest/demos/docs/api/events.html

_"swipe"_
- Triggers when a horizontal drag of 30px or more (and less than 20px vertically) occurs within 1 second duration but these can be configured:
- **scrollSupressionThreshold** (default: 10px) – More than this horizontal displacement, and we will suppress scrolling
- **durationThreshold** (default: 1000ms) – More time than this, and it isn’t a swipe
- **horizontalDistanceThreshold** (default: 30px) – Swipe horizontal displacement must be more than this.
- **verticalDistanceThreshold** (default: 75px) – Swipe vertical displacement must be less than this.
