### PR TITLE
Return an empty array when querying an invalid nodeType

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -105,6 +105,7 @@ var Zepto = (function() {
     var found;
     return (element === document && idSelectorRE.test(selector)) ?
       ( (found = element.getElementById(RegExp.$1)) ? [found] : emptyArray ) :
+      (element.nodeType !== 1 && element.nodeType !== 9) ? emptyArray :
       slice.call(
         classSelectorRE.test(selector) ? element.getElementsByClassName(RegExp.$1) :
         tagSelectorRE.test(selector) ? element.getElementsByTagName(selector) :

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -871,6 +871,12 @@
         t.assertLength(11, found);
       },
 
+      testFindWithInvalidNode: function(t) {
+        var found = $('<div><a>1</a></div>\n<div></div>').find('a');
+        t.assertLength(1, found);
+        t.assertEqual('1', found.get(0).innerHTML);
+      },
+
       testFilter: function(t){
         var found = $('div');
         t.assertLength(2, found.filter('.filtertest'));


### PR DESCRIPTION
$$ should return an empty array when querying an invalid nodeType. TypeError's occur when parsing templates with newlines (between root elements) into the Zepto object, then running "find" on them.
