### PR TITLE
Fix for multiple arguments to .append etc (#413)

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -63,8 +63,8 @@ var Zepto = (function() {
 
   function fragment(html, name) {
     if (name === undefined) {
-	if (!fragmentRE.test(html)) return document.createTextNode(html);
-	name = RegExp.$1;
+        if (!fragmentRE.test(html)) return document.createTextNode(html);
+        name = RegExp.$1;
     }
     if (!(name in containers)) name = '*';
     var container = containers[name];

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1169,7 +1169,7 @@
       },
 
       testAppendPrependBeforeAfter: function(t){
-	//test with string parameter
+        //test with string parameter
         $('#beforeafter').append('append');
         $('#beforeafter').prepend('prepend');
         $('#beforeafter').before('before');
@@ -1191,7 +1191,7 @@
 
         t.assertEqual('before<div id="beforeafter">prependappend</div>after', $('#beforeafter_container').html());
 
-	//test with multiple strings as parameters
+        //test with multiple strings as parameters
         $('#beforeafter_container').html('<div id="beforeafter"></div>');
         $('#beforeafter').append('append1','append2');
         $('#beforeafter').prepend('prepend1','prepend2');
@@ -1279,7 +1279,7 @@
         //testing with more than one Zepto object as parameter
         $('#beforeafter_container').html('<div id="beforeafter"></div>');
 
-	//testing with more than one Zepto object as parameters
+        //testing with more than one Zepto object as parameters
         $('#beforeafter').append($(div('append1')),$(div('append2')));
         $('#beforeafter').prepend($(div('prepend1')),$(div('prepend2')));
         $('#beforeafter').before($(div('before1')),$(div('before2')));


### PR DESCRIPTION
G'day, I just made some minor changes to get the behaviour closer to jQuery. 

The changes around zepto.js:444 `adjacencyOperators.forEach(` ... I think are pretty obvious, but I couldn't get it to work on the "plain text" test case and had to make some changes to fragment() as well, such that if it is handed something that doesn't look like XML it turns it into a TextNode.

cheers,
-- Nick
