### PR TITLE
Transition properties set to `all` causing undesired transitions

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -53,7 +53,11 @@
         else cssProperties[key] = properties[key]
 
       if (transforms) cssProperties[prefix + 'transform'] = transforms.join(' ')
-      if (!$.fx.off) cssProperties[prefix + 'transition'] = 'all ' + duration + 's ' + (ease || '')
+      if (!$.fx.off && typeof properties === 'object') {
+        cssProperties[prefix + 'transition-property'] = Object.keys(properties).join(', ')
+        cssProperties[prefix + 'transition-duration'] = duration + 's'
+        cssProperties[prefix + 'transition-timing-function'] = (ease || 'linear')
+      }
     }
 
     wrappedCallback = function(event){
@@ -62,7 +66,12 @@
         $(event.target).unbind(endEvent, arguments.callee)
       }
       var props = {}
-      props[prefix + 'transition'] = props[prefix + 'animation-name'] = 'none'
+      props[prefix + 'transition-property'] = ''
+      props[prefix + 'transition-duration'] = ''
+      props[prefix + 'transition-timing-function'] = ''
+      props[prefix + 'transition-timing-function'] = ''
+      props[prefix + 'animation-name'] = ''
+      props[prefix + 'animation-duration'] = ''
       $(this).css(props)
       callback && callback.call(this)
     }

--- a/test/fx.html
+++ b/test/fx.html
@@ -163,7 +163,12 @@
           t.resume(function(){
             t.assert($(context).is('#callbacktest'), "context for callback is wrong")
             t.assert((new Date().getTime() - start) >= duration, 'Fired too early')
-            t.assertStyle(/^(none( 0s ease 0s ?)?)?$/, context, 'transition')
+            t.assertStyle('', context, 'transition')
+            t.assertStyle('', context, 'transition-property')
+            t.assertStyle('', context, 'transition-timing-function')
+            t.assertStyle('', context, 'transition-duration')
+            t.assertStyle('', context, 'animation-name')
+            t.assertStyle('', context, 'animation-duration')
           })
         })
 


### PR DESCRIPTION
If you want to instantaneously alter the CSS of an element while some of its properties are being animated with a call to zepto's `animate()` function, the alteration to the CSS is animated too. This is because the transition was set using the shorthand syntax where only one property can be applied and 'all' was used, eg.: `transition: all 0.3s ease-in-out;`.

I have factored out the transition into the more explicit components, `transition-property`, `transition-duration` and `transition-timing-function` so that only the properties that are modified in the call to `animate()` are transitioned.

This fixes my use case where an element that had an animation sprite as its background (so no transition required on `background-position`), was animated across the screen (transition required on `transform`).

I have updated the test `fx.html` to reflect this change.
