### PR TITLE
Expect $(domElement1, domElement2) to return [domElement1] like jQuery.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -78,7 +78,6 @@ var Zepto = (function() {
 
   function $(selector, context){
     if (!selector) return Z();
-    if (context !== undefined) return $(context).find(selector);
     else if (isF(selector)) return $(document).ready(selector);
     else if (selector instanceof Z) return selector;
     else {
@@ -89,6 +88,7 @@ var Zepto = (function() {
       else if (fragmentRE.test(selector))
         dom = fragment(selector.trim(), RegExp.$1), selector = null;
       else if (selector.nodeType && selector.nodeType == 3) dom = [selector];
+      else if (context !== undefined) return $(context).find(selector);
       else dom = $$(document, selector);
       return Z(dom, selector);
     }

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -377,9 +377,12 @@
         var zepto = $('p#find1, #find2');
         t.assertLength(11, $('span', zepto));
 
-        // DOM Element
+        // Selector with DOM Element Context
         var domElement = document.getElementById('find1');
         t.assertLength(4, $('span.findme', domElement));
+
+        // DOM Element with DOM Element Context
+        t.assertLength(1, $(domElement, domElement));
       },
 
       testDollarWithDocument: function(t){


### PR DESCRIPTION
Sometimes we anchor Zepto to a particular DOM element to make querying easier eg:

```
function anchor(context) {
    return function(selector) {
        return Zepto(selector, context)
    }
}

var $ = anchor(domElement)
$('h1')
$(otherDomElement)
```

Currently passing a DOM element and a context results in an error.
