### PR TITLE
add version number to zepto code. similar to jquery

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -158,6 +158,8 @@ var Zepto = (function() {
   }
 
   $.fn = {
+    // The current version of Zepto being used
+    zepto: "0.1",
     forEach: emptyArray.forEach,
     reduce: emptyArray.reduce,
     push: emptyArray.push,


### PR DESCRIPTION
I left the version as 0.1, since I was not sure what current version the library is currently on. But this information could be useful.

I can assist in automating this in some fashion, to read from a file or something .. so we can incorporated as part of the build process and also insert it into the README, etc.
