### PR TITLE
Fixing transitionEnd-Event Bubble-Error Issue #305

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -57,10 +57,10 @@
     }
 
     wrappedCallback = function(event){
-      if (event.target !== event.currentTarget) {
-        return;
+      if (typeof event !== 'undefined') {
+        if (event.target !== event.currentTarget) return; // makes sure the event didn't bubble from "below"
+        $(event.target).unbind(endEvent, arguments.callee);
       }
-      $(event.target).unbind(endEvent, arguments.callee);
       var props = {};
       props[prefix + 'transition'] = props[prefix + 'animation-name'] = 'none';
       $(this).css(props);

--- a/test/fx.html
+++ b/test/fx.html
@@ -43,7 +43,7 @@
   <div id="animtest_2" style="width:40px;height:40px;background:red"></div>
   <div id="durationtest_1" style="width:40px;height:40px;background:red"></div>
   <div id="durationtest_2" style="width:40px;height:40px;background:red"></div>
-  <div id="callbacktest" style="width:40px;height:40px;background:red"></div>
+  <div id="callbacktest" style="width:40px;height:40px;background:red"><div style="width:40px;height:40px;background:blue"></div></div>
   <div id="keyframetest" style="width:40px;height:40px;background:red;opacity: 0;"></div>
 
   <div id="anim_zero_duration_callback_test"></div>
@@ -162,10 +162,13 @@
           var context = this;
           t.resume(function(){
             t.assert($(context).is('#callbacktest'), "context for callback is wrong");
-            t.assert((new Date().getTime() - start) >= duration);
+            t.assert((new Date().getTime() - start) >= duration, 'Fired too early');
             t.assertStyle(/^(none( 0s ease 0s ?)?)?$/, context, 'transition');
           });
         });
+
+        // tests bubbling
+        $('#callbacktest div').anim({ opacity: 0.0 }, 0.1, 'linear');
 
         var el = $('#anim_zero_duration_callback_test'),
             callbackCalled = false;


### PR DESCRIPTION
I fixed #305 by checking for the identity of event.target and event.currentTarget.
This made the switch from .one to .bind neccessary, as the event could occur multiple times. It is then unbound manually.
