### PR TITLE
calling val() on non existent element should return undefined

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -333,7 +333,7 @@ var Zepto = (function() {
     },
     val: function(value){
       return (value === undefined) ?
-        (this.length > 0 ? this[0].value : null) :
+        (this.length > 0 ? this[0].value : undefined) :
         this.each(function(idx){
           this.value = funcArg(this, value, idx, this.value);
         });

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1138,6 +1138,8 @@
 
         input.val(function(i, val){ return val.replace('Hello', 'Bye') });
         t.assertEqual('Bye again', input.val());
+
+        t.assertUndefined($('non-existent').val());
       },
 
       testChaining: function(t){


### PR DESCRIPTION
jQuery returns undefined and not null when you call `$('non-existent').val()`. Making sure Zepto behaves the same way to maintain compaitibility
