### PR TITLE
extend should not copy over undefined values

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -96,7 +96,9 @@ var Zepto = (function() {
 
   $.extend = function(target){
     slice.call(arguments, 1).forEach(function(source) {
-      for (key in source) target[key] = source[key];
+      for (key in source)
+        if (source[key] !== undefined)
+          target[key] = source[key];
     })
     return target;
   }

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -305,6 +305,9 @@
         obj = {};
         t.assertIdentical(obj, $.extend(obj, {a: 1}, {b: 2}))
         t.assertEqual(2, obj.b);
+
+        // undefined values are not copied over
+        t.assertSame({a:1}, $.extend({a:1}, {b:undefined}));
       },
 
       testDollar: function(t){


### PR DESCRIPTION
jQuery does not copy over undefined values when extending objects. To maintain compatibility, I've made Zepto behave the same.

http://james.padolsey.com/jquery/#v=1.6.2&fn=jQuery.extend

Scroll down towards the bottom where it says "Don't bring in undefined values"
