### PR TITLE
Use isFunction not typeof within isPlainObject

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -30,7 +30,7 @@ var Zepto = (function() {
   function isPlainObject(value) {
     var key, ctor
     if (toString.call(value) !== "[object Object]") return false
-    ctor = (typeof value.constructor === 'function' && value.constructor.prototype)
+    ctor = (isFunction(value.constructor) && value.constructor.prototype)
     if (!ctor || !hasOwnProperty.call(ctor, 'isPrototypeOf')) return false
     for (key in value);
     return key === undefined || hasOwnProperty.call(value, key)


### PR DESCRIPTION
isPlainObject was using typeof not the provided isFunction helper which uses preferred type checking approach for functions (see #461 & 61230f5)
