### PR TITLE
css(property,'') removes the style as in jquery - both usage cases

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -439,10 +439,20 @@ var Zepto = (function() {
             : this[0].style[camelize(property)] || getComputedStyle(this[0], '').getPropertyValue(property)
         )
       }
-      var css = ''
-      for (key in property) css += dasherize(key) + ':' + maybeAddPx(key, property[key]) + ';'
-      if (typeof property == 'string') css = dasherize(property) + ":" + maybeAddPx(property, value)
-      return this.each(function(){ this.style.cssText += ';' + css })
+      var css = '';
+      for (key in property) {
+        if(typeof property[key] == 'string' && property[key] == '')
+          this.each(function() {this.style.removeProperty(dasherize(key))});
+        else
+          css += dasherize(key) + ':' + maybeAddPx(key, property[key]) + ';';
+      }
+      if (typeof property == 'string') {
+        if (value == '')
+          this.each(function() {this.style.removeProperty(dasherize(property))});
+        else
+          css = dasherize(property) + ":" + maybeAddPx(property, value);
+      }
+      return this.each(function() { this.style.cssText += ';' + css });
     },
     index: function(element){
       return element ? this.indexOf($(element)[0]) : this.parent().children().indexOf(this[0])

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1090,6 +1090,13 @@
         var div = $('#get_style_element')
         t.assertEqual('48px', div.css('font-size'))
         t.assertEqual('rgb(0, 0, 0)', div.css('color'))
+
+        $('#some_element').css('color', '')
+        t.assertEqual('', el.style.color)
+
+        $('#some_element').css({'margin-top': '', 'marginBottom': ''})
+        t.assertEqual('', el.style.marginTop)
+        t.assertEqual('', el.style.marginBottom)
       },
 
       testCSSOnNonExistElm: function (t) {


### PR DESCRIPTION
Patch from @gregorymostizky for #327 with tests.
