### PR TITLE
hasClass() compatible with SVG DOM where SVGAnimatedString is used

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -343,7 +343,7 @@ var Zepto = (function() {
     },
     hasClass: function(name){
       if (this.length < 1) return false;
-      else return classRE(name).test(this[0].className);
+      else return classRE(name).test(this[0].className.baseVal === undefined ? this[0].className : this[0].className.baseVal);
     },
     addClass: function(name){
       return this.each(function(idx) {


### PR DESCRIPTION
Hi,

I'm using Zepto with SVG and it works great so far. Not sure what's the philosophy of Zepto with regards to SVG DOM but I encountered a little issue with hasClass() function which is not compatible with SVG dom.

class in SVG DOM is a SVGAnimatedString with two properties baseVal and animVal where both are of DOMString type. I'm using the baseVal value in my fix to get the proper DOMString.

If you like it, more fixes will come in all places where className is used.
