### PR TITLE
get or set data using native `dataset`

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -412,7 +412,18 @@ var Zepto = (function() {
       return this.each(function(){ this.removeAttribute(name) })
     },
     data: function(name, value){
-      var data = this.attr('data-' + name, value)
+      if (this[0].dataset !== undefined) {
+        if (typeof name == 'string') {
+          if (value === undefined) {
+            return this[0].dataset[camelize(name)];
+          } else {
+            return this[0].dataset[camelize(name)] = value;
+          }
+        }
+      }
+
+      var data = this.attr('data-' + name, value);
+
       return data !== null ? data : undefined
     },
     val: function(value){


### PR DESCRIPTION
This PR has two purposes:
- The [W3C spec](http://www.w3.org/TR/html5/global-attributes.html#embedding-custom-non-visible-data-with-the-data-attributes) mentions that hyphenated names become camel-cased. For example, data-foo-bar="" becomes element.dataset.fooBar.
  This is not the current case of Zepto, since $.data('camelCase') will trigger the `getAttribute` of 'data-camelCase'. This is more inline with what jQuery does too.
- Use native dataset support when available, instead of getting/setting the attribute directly.

I haven't tested this with the data plugin currently available.
