### PR TITLE
Ajax: HTTP 304 status code should not be treated as error.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -192,7 +192,7 @@
       if (xhr.readyState == 4) {
         clearTimeout(abortTimeout)
         var result, error = false
-        if ((xhr.status >= 200 && xhr.status < 300) || (xhr.status == 0 && protocol == 'file:')) {
+        if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304 || (xhr.status == 0 && protocol == 'file:')) {
           dataType = dataType || mimeToDataType(xhr.getResponseHeader('content-type'))
           result = xhr.responseText
 

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -452,6 +452,17 @@
         t.refute(errorFired)
       },
 
+      test304ResponseIsSuccess: function(t) {
+        var successFired, errorFired
+        $.ajax({
+          success: function() { successFired = true },
+          error: function() { errorFired = true }
+        })
+
+        MockXHR.last.ready(4, 304, 'Not Modified')
+        t.assert(successFired)
+        t.refute(errorFired)
+      },
       testXHRParameterInSuccessCallback: function(t) {
         var body, status, xhr
         $.ajax({


### PR DESCRIPTION
This adds a test for issue #386.
