### PR TITLE
Removing the ms conversion

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -36,7 +36,6 @@
   $.fn.animate = function(properties, duration, ease, callback){
     if ($.isObject(duration))
       ease = duration.easing, callback = duration.complete, duration = duration.duration
-    if (duration) duration = duration / 1000
     return this.anim(properties, duration, ease, callback)
   }
 


### PR DESCRIPTION
The documentation says to specify the duration in seconds but the animate function is dividing the number by 1000 which would indicate it's expecting the value to be in milliseconds.
