### PR TITLE
Self-closing html tags act as open tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source :rubygems
 
 gem 'rake'
+gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,17 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    execjs (1.3.0)
+      multi_json (~> 1.0)
+    multi_json (1.3.2)
     rake (0.9.2.2)
+    uglifier (1.2.4)
+      execjs (>= 0.3.0)
+      multi_json (>= 1.0.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   rake
+  uglifier

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -101,6 +101,12 @@ var Zepto = (function() {
     if (name === undefined) name = fragmentRE.test(html) && RegExp.$1
     if (!(name in containers)) name = '*'
     var container = containers[name]
+
+    if(html.replace) {
+      var tagExpander = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/ig
+      html = html.replace(tagExpander, "<$1></$2>")
+    }
+
     container.innerHTML = '' + html
     return $.each(slice.call(container.childNodes), function(){
       container.removeChild(this)

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -525,6 +525,9 @@
         t.assertEqual("<span>world</span>", outerHTML(fragment.get(2)))
         t.assertEqual('', fragment.selector)
 
+        fragment = $("<div /><div />")
+        t.assertLength(2, fragment)
+
         fragment = $("<div>hello</div> ")
         t.assertLength(1, fragment)
       },


### PR DESCRIPTION
When creating DOM elements with an html string, self-closing html tags are interpreted by the browser and opening tags only. This happens when you set `innerHTML` on an element.

Happens Now:

```
$('<div /><div />')
<div>
  <div></div>
</div>
```

Expect to Happen:

```
$('<div /><div />')
<div></div>
<div></div>
```

To fix this, jQuery will split any self-closing tags into open-close tags before creating the elements. This pull request implements that technique in Zepto. I also added a test for this scenario.

jQuery Implementation Reference: https://github.com/jquery/jquery/blob/master/src/manipulation.js#L674

Side Effect: I added uglifier to the Gemfile since it's required to build the project. If you don't want to accept that part of this pull request, I can remove it.
