### PR TITLE
Prevent 'tap' event from beeing triggered after scrolling

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -63,6 +63,12 @@
 
       // normal tap
       } else if ('last' in touch) {
+        
+        if (Math.abs(touch.x1 - touch.x2) > 10 ||
+            Math.abs(touch.y1 - touch.y2) > 10) {
+          return;
+        }
+        
         touch.el.trigger('tap')
 
         touchTimeout = setTimeout(function(){


### PR DESCRIPTION
The tap event is always triggered after scrolling. So the element
which is under the finger after scrolling stops is triggered with a
'tap'. 
With my change the positions of 'touchstart' and 'touched' are compared.
Only if they are within an given threshold of 10 px, 'tap' is executed.

Thanks to Ryan Fioravanti :
http://code.google.com/intl/de-DE/mobile/articles/fast_buttons.html
