### PR TITLE
$.init broken for selector detection $(window.applicationCache)

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -14,6 +14,8 @@ var Zepto = (function() {
     // Used by `$.zepto.init` to wrap elements, text/comment nodes, document,
     // and document fragment node types.
     elementTypes = [1, 3, 8, 9, 11],
+    //Used by `$.zepto.init` to wrap non-node elements like window
+    elementNonNodes=[window, window.applicationCache],
 
     adjacencyOperators = [ 'after', 'prepend', 'before', 'append' ],
     table = document.createElement('table'),
@@ -148,7 +150,7 @@ var Zepto = (function() {
       else if (isPlainObject(selector))
         dom = [$.extend({}, selector)], selector = null
       // wrap stuff like `document` or `window`
-      else if (elementTypes.indexOf(selector.nodeType) >= 0 || selector === window)
+      else if (elementTypes.indexOf(selector.nodeType) >= 0 || elementNonNodes.indexOf(selector) >= 0)
         dom = [selector], selector = null
       // If it's a html fragment, create nodes from it
       else if (fragmentRE.test(selector))


### PR DESCRIPTION
hey robby!

here is a small fix for a problem i bumped into, while trying to register for the updateready events on the window.applicationCache object.
In RC1, your checking to see if an element is of a special nodeType or if its window. At the moment, window.applicationCache is identified as a selector.
I just added a further array to store such "window-y", or non-node elements to make a simple check in $.init for all of them (and more to come).

btw. this is my first pull request, so sorry, if I messed things up/didn't do as supposed!

p.S -> thanks for creating zepto! i've been eyeing you since 0.3, or was it 0.4? doesnt matter, your awesome! :)
p.S.S -> komm doch mal in die schöne Schweiz, z.B Zürich :) ist ja nur ein Katzensprung! und wir haben auch RedBull ;)
