### PR TITLE
Don't try and evaluate a script body if the script is being loaded remotely

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -562,7 +562,8 @@ var Zepto = (function() {
         for (var i = 0; i < nodes.length; i++) {
           var node = nodes[inReverse ? nodes.length-i-1 : i]
           traverseNode(node, function(node){
-            if (node.nodeName != null && node.nodeName.toUpperCase() === 'SCRIPT' && (!node.type || node.type === 'text/javascript'))
+            if (node.nodeName != null && node.nodeName.toUpperCase() === 'SCRIPT' &&
+               (!node.type || node.type === 'text/javascript') && !node.src)
               window['eval'].call(window, node.innerHTML)
           })
           if (copyByClone && index < size - 1) node = node.cloneNode(true)


### PR DESCRIPTION
If a src attribute is specified in a script tag, the body of the tag should typically be blank, and should not be evaluated. Certain sites, such as LinkedIn's Javascript library, rely on this non-evaluating behavior of the browsers to configure their library on load.

My commit updates zepto so it behaves identically when adding a script tag to the HTML page as when doing it programmatically with zepto.
