### PR TITLE
Add semicolon at the end of the zepto.js build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,9 @@ BuildTask.define_task 'dist/zepto.js' => DEFAULT_MODULES.map {|m| "src/#{m}.js" 
         zepto.puts line unless copyright
       end
     end
+    
+    # final semicolon to play nice when concating with other scripts
+    zepto.puts ";"
   end
 end
 


### PR DESCRIPTION
Zepto's lack of semicolons was causing me trouble when concating with other files (namely underscore). I was ending up with something like this:

```
})(Zepto)
// End of zepto
// Start of underscore.js
(function () {
```

Which obviously causes issues. Putting in a final semicolon at the end lets zepto play nice with other scripts.
