### PR TITLE
Use $.fn.concat instead of [].concat in flatten() function.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -55,7 +55,7 @@ var Zepto = (function() {
   function likeArray(obj) { return typeof obj.length == 'number' }
 
   function compact(array) { return array.filter(function(item){ return item !== undefined && item !== null }) }
-  function flatten(array) { return array.length > 0 ? [].concat.apply([], array) : array }
+  function flatten(array) { return array.length > 0 ? $.fn.concat.apply([], array) : array }
   camelize = function(str){ return str.replace(/-+(.)?/g, function(match, chr){ return chr ? chr.toUpperCase() : '' }) }
   function dasherize(str) {
     return str.replace(/::/g, '/')


### PR DESCRIPTION
To make zepto work in IE9, we need to override ugly native concat behavior. Without the change, that can be done only by changing Array.prototype. With it, we can surgically strike at $.fn.concat.

Other instances of concat in zepto are not problematic, as they either already run the fn version (like one in $.fn.add), or are called only on plain arrays (two instances in event handling code).
