### PR TITLE
Conflict between documentation and implementation on #animate

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -36,7 +36,7 @@
   $.fn.animate = function(properties, duration, ease, callback){
     if ($.isObject(duration))
       ease = duration.easing, callback = duration.complete, duration = duration.duration
-    if (duration) duration = duration / 1000
+    if (duration && duration > 1000) duration = duration / 1000
     return this.anim(properties, duration, ease, callback)
   }
 


### PR DESCRIPTION
This change alters the duration check line to only divide the incoming value by 1,000 if it is greater than 1,000.  Which makes the assumption that no one intends to have a css animation that takes more than 16.6 minutes, and actually passing in microseconds, against the API/Documentation's request.  If you don't like this assumption then just pass through the duration without any check.
