### PR TITLE
Protect ternary operators from being damaged by Firefox toString() conversion

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -407,7 +407,7 @@ var Zepto = (function() {
       return this.css("display", "none")
     },
     toggle: function(setting){
-      return (setting === undefined ? this.css("display") == "none" : setting) ? this.show() : this.hide()
+      return !!(setting === undefined ? this.css("display") == "none" : setting) ? this.show() : this.hide()
     },
     prev: function(selector){ return $(this.pluck('previousElementSibling')).filter(selector || '*') },
     next: function(selector){ return $(this.pluck('nextElementSibling')).filter(selector || '*') },
@@ -523,7 +523,7 @@ var Zepto = (function() {
     toggleClass: function(name, when){
       return this.each(function(idx){
         var newName = funcArg(this, name, idx, this.className)
-        ;(when === undefined ? !$(this).hasClass(newName) : when) ?
+        ;!!(when === undefined ? !$(this).hasClass(newName) : when) ?
           $(this).addClass(newName) : $(this).removeClass(newName)
       })
     }


### PR DESCRIPTION
There is an interesting bug in Firefox. When it performs a toString() conversion of a Javascript function, it will strip away brackets around the ternary operator condition. Sometimes, it leads to surprising results.

For example, if we do (function(a,b,c,d,e) { return (a ? b : c) ? d : e; }).toString(), we would get "function (a, b, c, d, e) { return a ? b : c ? d : e; }". Calling first function with parameters (1,2,3,4,5) will return 4, but calling second one will return 2. 

This breakable pattern is present in $.fn.toggle() and $.fn.toggleClass(), and is corrected in this patch by adding !! in front of the condition.

Now, you are probably wondering why would someone ever want to wrap Zepto in a function, call toString() on it and execute resulting code instead of running it directly. Environments where this could make sense include cross-frame or cross-domain development, rewriting existing document with document.open(), and extension development. The main window may load a bunch of scripts all concatenated in one file, and desire to send some of the scripts to child windows for execution. When one of these scripts is Zepto and target browser is Firefox, the bug rears it ugly head.
