### PR TITLE
Detect swipe before double-tap

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -49,16 +49,16 @@
     }).bind('touchend', function(e){
        cancelLongTap()
 
-      // double tap (tapped twice within 250ms)
-      if (touch.isDoubleTap) {
-        touch.el.trigger('doubleTap')
-        touch = {}
-
       // swipe
-      } else if ((touch.x2 && Math.abs(touch.x1 - touch.x2) > 30) ||
-                 (touch.y2 && Math.abs(touch.y1 - touch.y2) > 30)) {
+      if ((touch.x2 && Math.abs(touch.x1 - touch.x2) > 30) ||
+          (touch.y2 && Math.abs(touch.y1 - touch.y2) > 30)) {
         touch.el.trigger('swipe') &&
           touch.el.trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)))
+        touch = {}
+
+      // double tap (tapped twice within 250ms)
+      } else if (touch.isDoubleTap) {
+        touch.el.trigger('doubleTap')
         touch = {}
 
       // normal tap


### PR DESCRIPTION
Detecting swipe before double-tap makes sure that double tap is inside 30px radius. This prevents a tap-and-accidental-drag firing a double-tap.
