### PR TITLE
fix Android touchmove event bug

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -30,6 +30,14 @@
   }
 
   $(document).ready(function(){
+    
+    //fix Android touchmove event bug
+    document.body.addEventListener( "touchstart", function(e){
+		  if( navigator.userAgent.match(/Android/i) ) {
+			  e.preventDefault();
+		  }
+	  }, false );
+  
     var now, delta
 
     $(document.body).bind('touchstart', function(e){


### PR DESCRIPTION
touchmove events in Android web browsers have a really serious bug. If you don't include the following code, the touchmove event will fire once, but not again until you're done moving your touch, which utterly kills the usefulness of the touchmove event. It's a weird one, and may very well break more advanced touch logic that works on iOS. But if you preventDefault() on the touchstart event, your touchmove will function as expected.

This bug is documented here: 
http://code.google.com/p/android/issues/detail?id=5491
