### PR TITLE
Animation callback bug

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -73,15 +73,12 @@
         $(event.target).unbind(endEvent, arguments.callee)
       }
       $(this).css(clearProperties)
-	  
-      var t = this;
-      setTimeout(function(){
-		callback && callback.call(t)
-	  }, 0)
+
+      callback && callback.call(t)
     }
-    if (duration > 0) this.bind(endEvent, wrappedCallback)
 
     setTimeout(function() {
+      if (duration > 0) that.bind(endEvent, wrappedCallback)
       that.css(cssProperties)
       if (duration <= 0) setTimeout(function() {
         that.each(function(){ wrappedCallback.call(this) })


### PR DESCRIPTION
If TransitionEnd callbacks are added for element during its TransitionEnd event( new animation is started), added callbacks will be immediately executed(removed) and Zepto will perform no animation. So animation callback should be executed after TransitionEnd event.

``` html
<div style="width:100px;height:100px;border:1px solid black">HELLO WORLD</div>

<script src="../src/zepto.js"></script>
<script src="../src/event.js"></script>
<script src="../src/fx.js"></script>

<script>
    var d = $('div').anim({
        'rotate': '120deg',
        'opacity': .5,
        'border-color': 'red'
    }, 0.3, 'ease-out', function(){
        console.log('In (' + (new Date)*1 + ')');

        d.anim({
            'rotate': '0deg',
            'opacity': 1,
            'border-color': 'black'
        }, 0.3, 'ease-out', function(){
            console.log('Out    (' + (new Date)*1 + ')');
        });
    });
</script>
```
