### PR TITLE
Add an error handler for all event callbacks

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -41,7 +41,14 @@
       var delegate = getDelegate && getDelegate(fn, event),
         callback = delegate || fn
       var proxyfn = function (event) {
-        var result = callback.apply(element, [event].concat(event.data))
+        var result
+        if ($.onerror) {
+          try {
+            result = callback.apply(element, [event].concat(event.data))
+          } catch(e) { $.onerror(e) }
+        } else {
+          result = callback.apply(element, [event].concat(event.data))
+        }
         if (result === false) event.preventDefault()
         return result
       }


### PR DESCRIPTION
Javascript has a default error handler `window.onerror` though there are several issues with this, the most poignant being that you can't get at the error object itself, nor the associated stack trace.

Due to the large amount of code that ends up being run as a direct consequence of user-interaction on a webpage, allowing developers to catch all errors that are raised within event handlers added by zepto allows significantly improved debugging ability (particularly when coupled to a service like Airbrake or Bugsnag).

Obviously this is no substitute for handling errors locally; but it does significantly help with tracking down hard to find problems and unexpected exceptions.

This patch was inspired by a similar change made to ember.js https://github.com/emberjs/ember.js/compare/99125d9...539f5a1#L0R40 (MIT license).
