### PR TITLE
The methods focus() and blur() should be applied to all elements

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -209,7 +209,9 @@
   ;['focus', 'blur'].forEach(function(name) {
     $.fn[name] = function(callback) {
       if (callback) this.bind(name, callback)
-      else if (this.length) try { this.get(0)[name]() } catch(e){}
+      else this.forEach(function(element) {
+        try { element[name]() } catch(e){}
+      })
       return this
     }
   })


### PR DESCRIPTION
Consider the case $('input').blur() where $('input') returns two elements and the second one is selected. The current code only blurs the first one and the second one stays selected. Works OK in jQuery but fails in Zepto.
