### PR TITLE
Listen to `preventDefault` on the "tap" event, allowing it to prevent the "click" event.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -49,7 +49,7 @@ var Zepto = (function() {
   function isFunction(value) { return toString.call(value) == "[object Function]" }
   function isObject(value) { return value instanceof Object }
   function isPlainObject(value) {
-    return isObject(value) && Object.getPrototypeOf(value) == Object.prototype
+    return isObject(value) && value.__proto__ == Object.prototype
   }
   function isArray(value) { return value instanceof Array }
   function likeArray(obj) { return typeof obj.length == 'number' }
@@ -108,9 +108,7 @@ var Zepto = (function() {
   // `$.zepto.Z` swaps out the prototype of the given `dom` array
   // of nodes with `$.fn` and thus supplying all the Zepto functions
   // to the array. Note that `__proto__` is not supported on Internet
-  // Explorer. This method can be overriden in plugins but requires a
-  // custom build as it is invoked by plugins calling
-  // `$(document).ready`.
+  // Explorer. This method can be overriden in plugins.
   zepto.Z = function(dom, selector) {
     dom = dom || []
     dom.__proto__ = arguments.callee.prototype
@@ -142,7 +140,7 @@ var Zepto = (function() {
       // if a JavaScript object is given, return a copy of it
       // this is a somewhat peculiar option, but supported by
       // jQuery so we'll do it, too
-      else if ($.isPlainObject(selector))
+      else if (isPlainObject(selector))
         dom = [$.extend({}, selector)], selector = null
       // wrap stuff like `document` or `window`
       else if (elementTypes.indexOf(selector.nodeType) >= 0 || selector === window)


### PR DESCRIPTION
Fixes issue #511, where an element being moved on a tap event causes a different element to receive the click event.  This gives developers an option to prevent the default action.

Demo here: http://softwaresupportedknitting.com/zepto-tap-prevent-default/
