### PR TITLE
Load callback param fix

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -250,7 +250,7 @@
       self.html(selector ?
         $(document.createElement('div')).html(response.replace(rscript, "")).find(selector).html()
         : response)
-      success && success.call(self)
+      success && success.apply(self, arguments)
     })
     return this
   }

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -163,12 +163,15 @@
       testAjaxLoad: function(t) {
         var testEl = $('#ajax_load')
         t.pause()
-        var el = testEl.load('fixtures/ajax_load_simple.html', function(){
+        var el = testEl.load('fixtures/ajax_load_simple.html', function(response, status, xhr){
           var that = this
           deferredResume(t, function(){
             this.assertIdentical(testEl, that)
             this.assertEqual('simple ajax load', testEl.html().trim())
+            this.assert(response)
+            this.assertEqual("success", status)
           })
+          t.assertIn('abort', xhr)
         })
         t.assertIdentical(testEl, el)
       },


### PR DESCRIPTION
Fixes issue #545.  Makes `load` success callback arguments match documentation.  Unit test included.
