### PR TITLE
Ensure array's native filter()

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -3,7 +3,7 @@
 //     Zepto.js may be freely distributed under the MIT license.
 
 var Zepto = (function() {
-  var undefined, key, $, classList, emptyArray = [], slice = emptyArray.slice, filter = emptyArray.filter,
+  var undefined, key, $, classList, emptyArray = [], slice = emptyArray.slice,
     document = window.document,
     elementDisplay = {}, classCache = {},
     getComputedStyle = document.defaultView.getComputedStyle,
@@ -54,7 +54,7 @@ var Zepto = (function() {
   function isArray(value) { return value instanceof Array }
   function likeArray(obj) { return typeof obj.length == 'number' }
 
-  function compact(array) { return filter.call(array, function(item){ return item !== undefined && item !== null }) }
+  function compact(array) { return array.filter(function(item){ return item !== undefined && item !== null }) }
   function flatten(array) { return array.length > 0 ? $.fn.concat.apply([], array) : array }
   camelize = function(str){ return str.replace(/-+(.)?/g, function(match, chr){ return chr ? chr.toUpperCase() : '' }) }
   function dasherize(str) {
@@ -64,7 +64,7 @@ var Zepto = (function() {
            .replace(/_/g, '-')
            .toLowerCase()
   }
-  uniq = function(array){ return filter.call(array, function(item, idx){ return array.indexOf(item) == idx }) }
+  uniq = function(array){ return array.filter(function(item, idx){ return array.indexOf(item) == idx }) }
 
   function classRE(name) {
     return name in classCache ?
@@ -288,7 +288,7 @@ var Zepto = (function() {
     },
     filter: function(selector){
       if (isFunction(selector)) return this.not(this.not(selector))
-      return $(filter.call(this, function(element){
+      return $([].filter.call(this, function(element){
         return zepto.matches(element, selector)
       }))
     },
@@ -358,7 +358,7 @@ var Zepto = (function() {
     },
     siblings: function(selector){
       return filtered(this.map(function(i, el){
-        return filter.call(slice.call(el.parentNode.children), function(child){ return child!==el })
+        return slice.call(el.parentNode.children).filter(function(child){ return child!==el })
       }), selector)
     },
     empty: function(){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1085,6 +1085,14 @@
         t.assertEqualCollection([0,2], indexes)
       },
 
+      testFilterWithNonNativeArrayFilter: function(t){
+        var oldFilter = Array.prototype.filter
+        Array.prototype.filter = function() { return [] }
+        var found = $('div')
+        t.assertLength(2, found.filter('.filtertest'))
+        Array.prototype.filter = oldFilter
+      },
+
       testAdd: function(t){
         var lis=$("li"),spans=$("span"),
         together=lis.add("span"),


### PR DESCRIPTION
Hey guys, we hit a conflict with code that overwrote the native Array.filter.

This change seems inline with what is already happening with Array.slice.
