### PR TITLE
Prevent double tap for secondary touches.

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -49,7 +49,7 @@
         touchTimeout && clearTimeout(touchTimeout)
         touch.x1 = e.touches[0].pageX
         touch.y1 = e.touches[0].pageY
-        if (delta > 0 && delta <= 250) touch.isDoubleTap = true
+        if (delta > 0 && delta <= 250 && e.touches.length === 1) touch.isDoubleTap = true
         touch.last = now
         longTapTimeout = setTimeout(longTap, longTapDelay)
       })


### PR DESCRIPTION
This can occur if the browser registers two finger touches as two
distinct events rather than merging the two touches into one start
event.