### PR TITLE
Missing touchcancel protections

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -43,6 +43,13 @@
 
     $(document.body)
       .bind('touchstart', function(e){
+        if (e.touches.length === 1 && touch.x2) {
+          // Clear out touch movement data if we have it sticking around
+          // This can occur if touchcancel doesn't fire due to preventDefault, etc.
+          touch.x2 = undefined
+          touch.y2 = undefined
+        }
+
         now = Date.now()
         delta = now - (touch.last || now)
         touch.el = $(parentIfText(e.touches[0].target))
@@ -94,7 +101,7 @@
             else {
               touchTimeout = setTimeout(function(){
                 touchTimeout = null
-                touch.el.trigger('singleTap')
+                if (touch.el) touch.el.trigger('singleTap')
                 touch = {}
               }, 250)
             }


### PR DESCRIPTION
When using preventDefault of touchevents in parallel event handlers
the touchcancel event doesn't always trigger, leaving the touch
events in an inconsistent state. This fixes two errors resulting
from this:
- Phantom swipe events
- NPE on singleTap trigger
