### PR TITLE
Touch events don't return any position data.

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -37,7 +37,7 @@
     touchTimeout = tapTimeout = swipeTimeout = longTapTimeout = null
     touch = {}
   }
-  
+
   function trigger(eventName, cancelFunction) {
     var event, parameters = {
       position: {
@@ -47,9 +47,9 @@
         endY: touch.y2
       }
     }
-    
+
     if (cancelFunction) parameters.cancelTouch = cancelFunction
-    
+
     event = $.Event(eventName, parameters)
     touch.el.trigger(event)
   }
@@ -97,7 +97,7 @@
             // trigger universal 'tap' with the option to cancelTouch()
             // (cancelTouch cancels processing of single vs double taps for faster 'tap' response)
             trigger('tap', cancelAll)
-            
+
             // trigger double tap immediately
             if (touch.isDoubleTap) {
               trigger('doubleTap')

--- a/src/touch.js
+++ b/src/touch.js
@@ -19,7 +19,7 @@
   function longTap() {
     longTapTimeout = null
     if (touch.last) {
-      touch.el.trigger('longTap')
+      trigger('longTap')
       touch = {}
     }
   }
@@ -36,6 +36,22 @@
     if (longTapTimeout) clearTimeout(longTapTimeout)
     touchTimeout = tapTimeout = swipeTimeout = longTapTimeout = null
     touch = {}
+  }
+  
+  function trigger(eventName, cancelFunction) {
+    var event, parameters = {
+      position: {
+        startX: touch.x1,
+        startY: touch.y1,
+        endX: touch.x2,
+        endY: touch.y2
+      }
+    }
+    
+    if (cancelFunction) parameters.cancelTouch = cancelFunction
+    
+    event = $.Event(eventName, parameters)
+    touch.el.trigger(event)
   }
 
   $(document).ready(function(){
@@ -66,8 +82,8 @@
             (touch.y2 && Math.abs(touch.y1 - touch.y2) > 30))
 
           swipeTimeout = setTimeout(function() {
-            touch.el.trigger('swipe')
-            touch.el.trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)))
+            trigger('swipe')
+            trigger('swipe' + (swipeDirection(touch.x1, touch.x2, touch.y1, touch.y2)))
             touch = {}
           }, 0)
 
@@ -80,13 +96,11 @@
 
             // trigger universal 'tap' with the option to cancelTouch()
             // (cancelTouch cancels processing of single vs double taps for faster 'tap' response)
-            var event = $.Event('tap')
-            event.cancelTouch = cancelAll
-            touch.el.trigger(event)
-
+            trigger('tap', cancelAll)
+            
             // trigger double tap immediately
             if (touch.isDoubleTap) {
-              touch.el.trigger('doubleTap')
+              trigger('doubleTap')
               touch = {}
             }
 
@@ -94,7 +108,7 @@
             else {
               touchTimeout = setTimeout(function(){
                 touchTimeout = null
-                touch.el.trigger('singleTap')
+                trigger('singleTap')
                 touch = {}
               }, 250)
             }


### PR DESCRIPTION
This patch suggests a method by which the touch events could return the position of the initial touch and release for a touch event.

Currently the event that is passed to the client code does not include any positional data and sometimes it is significant to know where in the object the touch occurred.