### PR TITLE
Setting css opacity to 0 will result in opacity style being removed

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -487,7 +487,7 @@ var Zepto = (function() {
           css += dasherize(key) + ':' + maybeAddPx(key, property[key]) + ';'
 
       if (typeof property == 'string')
-        if (value == '')
+        if (value === '')
           this.each(function(){ this.style.removeProperty(dasherize(property)) })
         else
           css = dasherize(property) + ":" + maybeAddPx(property, value)

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1183,6 +1183,9 @@
         $('#some_element').css({'margin-top': '', 'marginBottom': ''})
         t.assertEqual('', el.style.marginTop)
         t.assertEqual('', el.style.marginBottom)
+
+				$('#some_element').css('opacity', 0)
+				t.assertIdentical('0', el.style.opacity)
       },
 
       testCSSOnNonExistElm: function (t) {


### PR DESCRIPTION
The css if test for removing a style is `value ==''` which of course will test positive for 0 values. This has implications for other kinds of styles. For example, if the border-width is set in an element to a non-zero value in the css file and we need to use the css function to add a 0 width on the element in some circumstance, this passes through.
