### PR TITLE
Make `children()` method work in XML documents

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -91,6 +91,14 @@ var Zepto = (function() {
     return elementDisplay[nodeName]
   }
 
+  function children(elem) {
+    return elem.children 
+      ? slice.call(elem.children) 
+      : slice.call(elem.childNodes).filter(function(node) {
+        return node.nodeType === 1;
+    });
+  }
+
   // `$.zepto.fragment` takes a html string and an optional tag name
   // to generate DOM nodes nodes from the given html string.
   // The generated DOM nodes are returned as an array.
@@ -376,14 +384,14 @@ var Zepto = (function() {
       return filtered(uniq(this.pluck('parentNode')), selector)
     },
     children: function(selector){
-      return filtered(this.map(function(){ return slice.call(this.children) }), selector)
+      return filtered(this.map(function(){ return children(this) }), selector)
     },
     contents: function() {
       return $(this.map(function() { return slice.call(this.childNodes) }))
     },
     siblings: function(selector){
       return filtered(this.map(function(i, el){
-        return slice.call(el.parentNode.children).filter(function(child){ return child!==el })
+        return children(el.parentNode).filter(function(child){ return child!==el })
       }), selector)
     },
     empty: function(){


### PR DESCRIPTION
The original implementation of `children()` method doesn’t work in XML documents (created in runtime or loaded by XHR), at least on my Safari 5/6 desktop: XML nodes doesn’t have `children` attribute.

This fix provides fallback on filtered `childNodes` set.
