### PR TITLE
Fix $.param()'s RegExp bug

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -276,6 +276,6 @@
     var params = []
     params.add = function(k, v){ this.push(escape(k) + '=' + escape(v)) }
     serialize(params, obj, traditional)
-    return params.join('&').replace('%20', '+')
+    return params.join('&').replace(/%20/g, '+')
   }
 })(Zepto)

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -650,6 +650,10 @@
         result = decodeURIComponent(result)
         t.assertEqual(result, "jquery=Javascript&rails=Ruby&django=Python")
 
+        result = $.param({ name: 'StuPig', description: 'a stupid guy' })
+        result = decodeURIComponent(result)
+        t.assertEqual(result, "name=StuPig&description=a+stupid+guy")
+
         result = $.param({
           title: "Some Countries",
           list: ['Ecuador', 'Austria', 'England'],


### PR DESCRIPTION
make `$.param()`'s behavior as described in the doc

``` javascript
$.param({ foo: 'bar', nested: { will: 'not be ignored' }})
//=> "foo=bar&nested[will]=not+be+ignored"
```
