### PR TITLE
Fix namespaced blur & focus delegate bug

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -128,13 +128,7 @@
   }
 
   $.fn.delegate = function(selector, event, callback){
-    var capture = false
-    if(event == 'blur' || event == 'focus'){
-      if($.iswebkit)
-        event = event == 'blur' ? 'focusout' : event == 'focus' ? 'focusin' : event
-      else
-        capture = true
-    }
+    var capture = /^(?:blur|focus)(?:\..*)?$/.test(event)
 
     return this.each(function(i, element){
       add(element, event, callback, selector, function(fn){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -2232,6 +2232,29 @@
         t.assertEqual(4, counter)
       },
 
+      testDelegateNamespacedBlurFocus: function(t) {
+        var counter = 0
+        $('#delegate_blur_test').delegate('input', 'blur.namespace_test', function(){ counter++ })
+
+        $('#delegate_blur_test').find('input').focus()
+        $('#delegate_blur_test').find('input').blur()
+        t.assertEqual(1, counter)
+
+        $('#delegate_blur_test').find('input').focus()
+        $('#delegate_blur_test').find('input').blur()
+        t.assertEqual(2, counter)
+
+        $('#delegate_focus_test').delegate('input', 'focus.namespace_test', function(){ counter++ })
+
+        $('#delegate_focus_test').find('input').focus()
+        $('#delegate_focus_test').find('input').blur()
+        t.assertEqual(3, counter)
+
+        $('#delegate_focus_test').find('input').focus()
+        $('#delegate_focus_test').find('input').blur()
+        t.assertEqual(4, counter)
+      },
+
       testDelegateReturnFalse: function(t){
         $(document.body).delegate('#some_element', 'click', function(){ return false })
 


### PR DESCRIPTION
Related issue: #552

Fixed a bug that prevented namespaced focus and blur events, attached through delegate(), from being triggered.

Besides the bug fix, this commit also cleans up some dead code - `if($.iswebkit)` will never evaluate to `true`.

On a side note, this fix brings Zepto a step closer to being a drop-in-replacement for jQuery in combination with Backbone. Backbone namespaces its events and uses `delegate()` for performance reasons. Most/a lot/some people will have binds to `blur` and `focus` as opposed to `focusin` and `focusout`.

**Another bug**
When writing tests for this fix I came across a different, but related bug (already present in Zepto). Calling `undelegate()` won't have any effect on `focus` and `blur` events attached through delegate() - or in other words events that have been attached using `capture` equals `true` ( `addEventListener(handler.e, proxyfn, capture)`) since events are always removed with `capture` equals `false` (`removeEventListener(handler.e, handler.proxy, false)`). I'll try to create a (seperate?) PR to fix this this week - but might not have the time - in which case I'll get it done start of next week.
