### PR TITLE
Logic error in tests.

### DIFF
--- a/test/zepto.html
+++ b/test/zepto.html
@@ -287,7 +287,7 @@
       if (typeof expected.get == 'function') expected = expected.get()
       if (typeof actual.get == 'function') actual = actual.get()
 
-      if (passed) for (var i=0; i<expected.length; i++) passed = expected[i] == actual[i]
+      if (passed) for (var i=0; i<expected.length; i++) passed &= expected[i] == actual[i];
 
       this._assertExpression(passed, message || 'Failed assertion.',
         'Expected %o, got %o.', expected, actual)


### PR DESCRIPTION
The pre-pull request overwrites the "pass" variable. This is inconsistent, and not a true test..

Example code that would fail:

``` javascript
Evidence.Assertions.assertEqualCollection({a:1,b:2}, {a:100, b:2}, 'foobar');
```
