### PR TITLE
Fix example in documentation for `$.proxy`.

### DIFF
--- a/event/_posts/1900-01-01-Z-proxy.md
+++ b/event/_posts/1900-01-01-Z-proxy.md
@@ -15,5 +15,5 @@ var obj = {name: 'Zepto'},
     handler = function(){ console.log("hello from + ", this.name) }
 
 // ensures that the handler will be executed in the context of `obj`:
-$(document).on('click', $.proxy(obj, handler))
+$(document).on('click', $.proxy(handler, obj))
 {% endhighlight %}


### PR DESCRIPTION
The current example has the parameters backwards, and results in `TypeError: expected function` when run.
