### PR TITLE
Split polyfill

### DIFF
--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -3,11 +3,14 @@
 //     Zepto.js may be freely distributed under the MIT license.
 
 ;(function(undefined){
-  if (String.prototype.trim === undefined) // fix for iOS 3.2
-    String.prototype.trim = function(){ return this.replace(/^\s+/, '').replace(/\s+$/, '') }
+  // fix for iOS 3.2
+  // from https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/String/Trim
+  String.prototype.trim = 
+    String.prototype.trim ||
+    function () { return this.replace(/^\s+|\s+$/g,'') }
 
   // For iOS 3.x
-  // from https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/reduce
+  // Adapted from https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/reduce
   if (Array.prototype.reduce === undefined)
     Array.prototype.reduce = function(fun){
       if(this === void 0 || this === null) throw new TypeError()


### PR DESCRIPTION
I basically changed the String.prototype.trim to a smaller version. I also added an attribution to MDN for using their String.prototype.trim.

Before my revision we _were_ at:
Minified: 24.916k
Minified and gzipped: 9.080k, compression factor 5.599

Now, we're at:
Minified: 24.897k
Minified and gzipped: 9.080k, compression factor 5.608

If we were using Google's Closure compiler, we might be able to squeeze out another 1k from the non-gzipped version, because it assumes type-safety, and will do minifications like this one at compile-time.
