### PR TITLE
improve the way undefined is used in a few places 

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -564,8 +564,7 @@ var Zepto = (function() {
     },
     css: function(property, value){
       if (arguments.length < 2 && typeof property == 'string')
-        return (
-          this[0] && this[0].style[camelize(property)] || getComputedStyle(this[0], '').getPropertyValue(property))
+        return this[0] && (this[0].style[camelize(property)] || getComputedStyle(this[0], '').getPropertyValue(property))
 
       var css = ''
       for (key in property)


### PR DESCRIPTION
These changes should have no effect on the logic and make the code slightly smaller and simpler. I couldn't run the tests locally. Please test.

Also, any idea why I can't run the tests?

```
$ rake test
script/test
Can't open 'test/runner.coffee'
rake aborted!
Command failed with status (255): [script/test...]

Tasks: TOP => test
(See full trace by running task with --trace)
$ ls test/runner.coffee 
test/runner.coffee
```
