### PR TITLE
Guard against Webkit's extraneous calls to xhr.onreadystatechange

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -195,6 +195,7 @@
 
     xhr.onreadystatechange = function(){
       if (xhr.readyState == 4) {
+        xhr.onreadystatechange = empty;
         clearTimeout(abortTimeout)
         var result, error = false
         if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304 || (xhr.status == 0 && protocol == 'file:')) {


### PR DESCRIPTION
In certain cases Webkit will call the onreadystatechange method of a single XMLHttpRequest object multiple times indicating that it is ready (readyState == 4).

This results in Zepto's 'success' or 'error' methods being called multiple times for the same AJAX request.

This is documented in this thread:
http://stackoverflow.com/questions/12761255/can-xhr-trigger-onreadystatechange-multiple-times-with-readystate-done

with a jsfiddle here:
http://jsfiddle.net/44b3P/

and confirmed here: 
http://osdir.com/ml/general/2012-10/msg12396.html
### To reproduce in Zepto:
1. visit http://jsfiddle.net/Rvk9j/1/ in Chrome (I'm using Chrome 22 for Mac) 
2. Open the debug console
3. Click the 'Run' button
4. When you reach the debugger statement, step forward (either click the Play button in Chrome's console or click F8) [1]

**Expected:** you should see 1 alert with the text 'error'

**Actual:** the alert with the text 'error' occurs 3 times

I'm working to find a way to reproduce this and submit upstream (at least to Chrome -- maybe to Webkit? -- We think it's a Webkit bug since we first observed this issue in Safari on iOS 6). 

In the meantime this patch should resolve the issue in Zepto.

[1] While this is an awkward way to reproduce (clearly a debugger statement shouldn't be in production code) we've observed similar behavior in our production code where success functions are called multiple times for the same AJAX request -- usually when there's a lot going on on the page or the page hasn't completed loading. 

The 'debugger' statement was the most reliable way I've seen to approximate these conditions and reproduce the behavior.
