### PR TITLE
wrap() working only on elements that are part of document

### DIFF
--- a/core/_posts/1900-01-01-wrap.md
+++ b/core/_posts/1900-01-01-wrap.md
@@ -5,10 +5,14 @@ signature: |
   wrap(function(index){ ... }) ⇒ self [v1.0]
 ---
 
-Wrap each element of the collection separately in a DOM structure. Structure can
+Wrap each element of the collection separately in a DOM structure. `structure` can
 be a single element or several nested elements, and can be passed in as a HTML
 string or DOM node, or as a function that is called for each element and returns
 one of the first two types.
+
+Note that just as with jQuery, the collection elements must be existing DOM nodes.
+You cannot wrap a newly-created element.
+That is, `$('<em>foo</em>').wrap('<li>')` won't work.
 
 {% highlight js %}
 // wrap each button in a separate span:


### PR DESCRIPTION
This is the no. 1 comment on  [jQuery's documentation of wrap](http://api.jquery.com/wrap/#comment-128249629) - that you have to inject the element in the DOM first.

However, it's not at all clearly intuitive to a new user why `$('<p class="new-element">').wrap("div")` wouldn't do anything.
