### PR TITLE
Passing test case against http://bugs.jquery.com/ticket/12881

### DIFF
--- a/test/zepto.html
+++ b/test/zepto.html
@@ -608,6 +608,13 @@
         t.assertEqual('red', el.css('color'))
       },
 
+      testDollarAFragmentWithProperties: function(t){
+        var zepto = $('<a>Goodbye</a>', { text: "Hello", href: "http://zepto.com" })
+        t.assertLength(1, zepto)
+        t.assertEqual('Hello', zepto.text())
+        t.assertEqual('http://zepto.com', zepto.attr("href"))
+      },
+
       testDollarWithTextNode: function(t){
         var textNode = $(document.createTextNode('hi there'))
         t.assertLength(1, textNode)


### PR DESCRIPTION
http://api.jquery.com/jQuery/ states that "As of jQuery 1.4, the second argument to jQuery() can accept a map consisting of a superset of the properties that can be passed to the `.attr()` method."

Turns out that [actually](http://bugs.jquery.com/ticket/12881),

> The only HTML you can use with that signature is a simple element with no attributes, such as `$("<a/>", { ... })`. I strongly recommend you not use the signature at all and used chaining instead.

Zepto behaves better than jQuery in this case. Added a test case to make sure this nice behavior is preserved.
