### PR TITLE
fixes to $.ajaxJSONP

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -75,32 +75,40 @@
 
     var callbackName = 'jsonp' + (++jsonpID),
       script = document.createElement('script'),
-      abort = function(){
+      cleanup = function() {
+        clearTimeout(abortTimeout)
         $(script).remove()
-        if (callbackName in window) window[callbackName] = empty
+        delete window[callbackName]
+      },
+      abort = function(){
+        cleanup()
         ajaxComplete('abort', xhr, options)
       },
       xhr = { abort: abort }, abortTimeout
 
-    if (options.error) script.onerror = function() {
-      xhr.abort()
-      options.error()
+    serializeData(options)
+
+    if (ajaxBeforeSend(xhr, options) === false) {
+      ajaxError(null, 'abort', xhr, options)
+      return false
     }
 
     window[callbackName] = function(data){
-      clearTimeout(abortTimeout)
-      $(script).remove()
-      delete window[callbackName]
+      cleanup()
       ajaxSuccess(data, xhr, options)
     }
 
-    serializeData(options)
+    script.onerror = function() {
+      cleanup()
+      ajaxError(null, 'error', xhr, options)
+    }
+
     script.src = options.url.replace(/=\?/, '=' + callbackName)
     $('head').append(script)
 
     if (options.timeout > 0) abortTimeout = setTimeout(function(){
-        xhr.abort()
-        ajaxComplete('timeout', xhr, options)
+        cleanup()
+        ajaxError(null, 'timeout', xhr, options)
       }, options.timeout)
 
     return xhr

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -134,6 +134,17 @@
         })
       },
 
+      testAjaxGetJSONPBeforeSendCallback: function(t){
+        t.pause()
+        var xhr = $.ajaxJSONP({
+          url: 'fixtures/jsonp.js?callback=?&timestamp='+(+new Date),
+          beforeSend: function() {
+            t.assert(true)
+            deferredResume(t)
+          }
+        })
+      },
+
       testAjaxGetJSONPErrorCallback: function(t){
         t.pause()
         $.ajax({
@@ -143,6 +154,19 @@
           success: function() { t.refute(true) },
           error: function() { t.assert(true) },
           complete: function() { deferredResume(t) }
+        })
+      },
+
+      testAjaxGetJSONPErrorWithoutErrorCallback: function(t){
+        t.pause()
+        $.ajax({
+          type: 'GET',
+          url: 'fixtures/404.js?timestamp='+(+new Date),
+          dataType: 'jsonp',
+          complete: function() {
+            t.assert(true)
+            deferredResume(t)
+          }
         })
       },
 


### PR DESCRIPTION
When making **JSONP** requests:
1. `settings.beforeSend` wasn't being called.
2. The `ajaxBeforeSend` and `ajaxError` events weren't being fired.
3. There was inconsistent behavior with timeouts between `$.ajax` and `$.ajaxJSONP`. In `$.ajax` when there is a timeout, `ajaxError` is called and that subsequentely calls `ajaxComplete`. In `$.ajaxJSONP`, a timeout skips `ajaxError` and calls `ajaxComplete` twice. First with a status of _abort_ and then again with a status of _timeout_.
4. When the request is aborted either by (1) calling `xhr.abort()` or (2) because of a timeout, or (3) the request raises an `onerror` event, the global `window[callbackName]` is set to `function empty () {}` instead of deleting it. So the global scope stays polluted and `empty()` retains a reference to `<script>` which then can't be garbage collected.
5. When a request is aborted before completion/timeout by calling `xhr.abort()` and there is a timeout set, the timeout would not to be cleared.
6. If you didn't specify an error callback in the options of `$.ajaxJSONP` and there is an error then there is no cleaning up of `<script>` or `window[callbackName]`, the error event isn't fired, and `$.active` isn't updated. (Kinda related to 4).

I only wrote tests for (1) and (6). Any help?
