### PR TITLE
Use `originalEvent` if available for jQuery compatibility 

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -43,6 +43,7 @@
 
     $(document.body)
       .bind('touchstart', function(e){
+        e = e.originalEvent || e
         now = Date.now()
         delta = now - (touch.last || now)
         touch.el = $(parentIfText(e.touches[0].target))
@@ -54,6 +55,7 @@
         longTapTimeout = setTimeout(longTap, longTapDelay)
       })
       .bind('touchmove', function(e){
+        e = e.originalEvent || e
         cancelLongTap()
         touch.x2 = e.touches[0].pageX
         touch.y2 = e.touches[0].pageY


### PR DESCRIPTION
Zepto's `touch.js` is widely used, with or without Zepto, as evidenced by relatively large numbers of pull requests on the file, especially since jQuery does not handle those events.

This simple patch will make `touch.js` "compatible" with jQuery, helping `touch.js` becomes somewhat a defacto standard. (we simply assign `window.Zepto = jQuery`, in case Zepto is not available.)

At jQTouch, we rather pull the effort into get `touch.js` and we are trying to rid our own. I really wish you will consider this patch. 

This patch pass all existing tests in `test/touch.html`, and I don't think it warrant a new tests. (but, feel free to suggest if you think one might be appropriate.)
