### PR TITLE
Multi-windows support for embedded scripts

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -746,8 +746,10 @@ var Zepto = (function() {
 
           traverseNode(parent.insertBefore(node, target), function(el){
             if (el.nodeName != null && el.nodeName.toUpperCase() === 'SCRIPT' &&
-               (!el.type || el.type === 'text/javascript') && !el.src)
-              window['eval'].call(window, el.innerHTML)
+               (!el.type || el.type === 'text/javascript') && !el.src){
+              var target = el.ownerDocument ? el.ownerDocument.defaultView : window
+              target['eval'].call(target, el.innerHTML)
+            }
           })
         })
       })


### PR DESCRIPTION
This should fix an issue with embedded scripts that are injected in a dynamically created IFRAME. If this operation is performed in the top window then the script is always evaluated there.