### PR TITLE
.trigger() and .triggerHandler() added default value for "data" argument

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -190,7 +190,7 @@
   $.fn.trigger = function(event, data){
     if (typeof event == 'string' || $.isPlainObject(event)) event = $.Event(event)
     fix(event)
-    event.data = data
+    event.data = data || []
     return this.each(function(){
       // items in the collection might not be DOM elements
       // (todo: possibly support events on plain old objects)
@@ -202,6 +202,7 @@
   // doesn't trigger an actual event, doesn't bubble
   $.fn.triggerHandler = function(event, data){
     var e, result
+    data = data || []
     this.each(function(i, element){
       e = createProxy(typeof event == 'string' ? $.Event(event) : event)
       e.data = data


### PR DESCRIPTION
If I will not pass data like this

```
 node.triggerHandler('click')
```

then handlers will have not one argument (event), but two: event and undefined, because in proxy method of handler you concatenate [event].concat(event.data)

event.data should be array in any case
