### PR TITLE
Add event callback scope in all event-related functions

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -45,7 +45,7 @@
     return hover[type] || type
   }
 
-  function add(element, events, fn, selector, getDelegate, capture){
+  function add(element, events, fn, selector, getDelegate, capture, scope){
     var id = zid(element), set = (handlers[id] || (handlers[id] = []))
     eachEvent(events, fn, function(event, fn){
       var handler   = parse(event)
@@ -60,7 +60,7 @@
       handler.del   = getDelegate && getDelegate(fn, event)
       var callback  = handler.del || fn
       handler.proxy = function (e) {
-        var result = callback.apply(element, [e].concat(e.data))
+        var result = callback.apply(scope || element, [e, element].concat(e.data))
         if (result === false) e.preventDefault(), e.stopPropagation()
         return result
       }
@@ -93,9 +93,9 @@
     }
   }
 
-  $.fn.bind = function(event, callback){
+  $.fn.bind = function(event, callback, scope){
     return this.each(function(){
-      add(this, event, callback)
+      add(this, event, callback, undefined, undefined, undefined, scope)
     })
   }
   $.fn.unbind = function(event, callback){
@@ -103,15 +103,15 @@
       remove(this, event, callback)
     })
   }
-  $.fn.one = function(event, callback){
+  $.fn.one = function(event, callback, scope){
     return this.each(function(i, element){
       add(this, event, callback, null, function(fn, type){
         return function(){
-          var result = fn.apply(element, arguments)
+          var result = fn.apply(scope || element, arguments)
           remove(element, type, fn)
           return result
         }
-      })
+      }, undefined, scope)
     })
   }
 
@@ -150,17 +150,17 @@
     }
   }
 
-  $.fn.delegate = function(selector, event, callback){
+  $.fn.delegate = function(selector, event, callback, scope){
     return this.each(function(i, element){
       add(element, event, callback, selector, function(fn){
         return function(e){
           var evt, match = $(e.target).closest(selector, element).get(0)
           if (match) {
             evt = $.extend(createProxy(e), {currentTarget: match, liveFired: element})
-            return fn.apply(match, [evt].concat([].slice.call(arguments, 1)))
+            return fn.apply(scope || match, [evt, match].concat([].slice.call(arguments, 1)))
           }
         }
-      })
+      }, undefined, scope)
     })
   }
   $.fn.undelegate = function(selector, event, callback){
@@ -178,9 +178,9 @@
     return this
   }
 
-  $.fn.on = function(event, selector, callback){
+  $.fn.on = function(event, selector, callback, scope){
     return !selector || $.isFunction(selector) ?
-      this.bind(event, selector || callback) : this.delegate(selector, event, callback)
+      this.bind(event, selector || callback, scope = callback) : this.delegate(selector, event, callback, scope)
   }
   $.fn.off = function(event, selector, callback){
     return !selector || $.isFunction(selector) ?


### PR DESCRIPTION
Add the ability to bind an event listener function to a certain
(optional) scope. Since the element was the default scope, also added
the element as a parameter to the function being called.
