### PR TITLE
Mark contents() method as "v1.0+" in documentation

### DIFF
--- a/core/_posts/1900-01-01-contents.md
+++ b/core/_posts/1900-01-01-contents.md
@@ -1,5 +1,6 @@
 ---
 title: contents
+version: 1.0
 signature: |
   contents() ⇒ collection
 ---


### PR DESCRIPTION
Fix it according to #686
