### PR TITLE
Update core/_posts/1900-01-01-Z-contains.md

### DIFF
--- a/core/_posts/1900-01-01-Z-contains.md
+++ b/core/_posts/1900-01-01-Z-contains.md
@@ -5,5 +5,5 @@ signature: |
   $.contains(parent, node) ⇒ boolean
 ---
 
-Check if the parent node contains the given DOM node. Returns false is both
+Check if the parent node contains the given DOM node. Returns false if both
 are the same node.


### PR DESCRIPTION
spelling error in $.contains description.
