### PR TITLE
Removed trailing space which was breaking Closure compiler

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -144,7 +144,7 @@
     // Whether data should be serialized to string
     processData: true,
     // Whether the browser should be allowed to cache GET responses
-    cache: true,
+    cache: true
   }
 
   function mimeToDataType(mime) {


### PR DESCRIPTION
Closure compiler was complaining about that one and required ES5 `language_in` mode.
