### PR TITLE
Added composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "madrobby/zepto"
+  , "description": "Zepto.js is a minimalist JavaScript library for modern browsers, with a jQuery-compatible API"
+  , "homepage": "http://zeptojs.com"
+  , "license": "MIT"
+}


### PR DESCRIPTION
This is a very basic composer.json file that allows composer users to include the package as a dependency.

All that could be done after accepting this (if it gets accepted) is optionally add this package to http://packagist.org. But it's not required, because composer users can simply add the repository url like this.
