### PR TITLE
getPrototype() with IE6 and IE6+ compatibility

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -51,18 +51,13 @@ var Zepto = (function() {
     return obj == null ? String(obj) :
       class2type[toString.call(obj)] || "object"
   }
-  function getPrototype(obj) {
-    if (Object.getPrototypeOf) { return Object.getPrototypeOf(obj); }
-    else if ('__proto__' in obj) { return obj.__proto__; }
-    else if ('constructor' in obj) { return obj.constructor.prototype; }
-    else { return null; }
-  }
   function isFunction(value) { return type(value) == "function" }
   function isWindow(obj)     { return obj != null && obj == obj.window }
   function isDocument(obj)   { return obj != null && obj.nodeType == obj.DOCUMENT_NODE }
   function isObject(obj)     { return type(obj) == "object" }
   function isPlainObject(obj) {
-    return isObject(obj) && !isWindow(obj) && getPrototype(obj) == Object.prototype
+    if (typeof(obj) == 'string') return false
+    return isObject(obj) && !isWindow(obj) && Object.prototype.isPrototypeOf(obj)
   }
   function isArray(value) { return value instanceof Array }
   function likeArray(obj) { return typeof obj.length == 'number' }


### PR DESCRIPTION
...ainObject() modification.

obj.**proto** isn't defined in IE, the value is always 'undefined'.
This method return in IE with the obj.constructor.prototype property, which is equal with the obj.**proto** value (when the browser defined this).

This method enabled the #654 issue related implementation in function isPlainObject().
