### PR TITLE
Test to show tap and click events

### DIFF
--- a/test/touch_manual.html
+++ b/test/touch_manual.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+  <link rel="stylesheet" href="test.css">
+  <title>Zepto touch unit tests</title>
+  <script src="../vendor/evidence.js"></script>
+  <script src="evidence_runner.js"></script>
+  <script src="../src/polyfill.js"></script>
+  <script src="../src/zepto.js"></script>
+  <script src="../src/event.js"></script>
+  <script src="../src/touch.js"></script>
+</head>
+<body>
+  <h1>Manual Touch tests - hit the red area.</h1>
+  <p id="results">
+    Running… see browser console for results
+  </p>
+
+  <style>
+    #test, .test {
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100px;
+      height: 50px;
+    }
+    .test {
+      background-color: #FF0000;
+      font-size: 1.4em;
+  </style>
+
+  <script>
+  (function(){
+
+    Evidence('TouchTest', {
+      setUp: function(){
+        $('<div id=test>TEST ELEMENT</div>').appendTo('body')
+        $('<div id=testTop class="test">Please tap me</div>').appendTo('body')
+      },
+
+      tearDown: function(){
+        $('#test').off()
+        $('#test').remove()
+        $('#testTop').off()
+        $('#testTop').remove()
+      },
+
+      // Test tap with 2 stacked elements, hiding the top one in touch event
+      testStackedTap: function(t){
+        var topCount = 0, bottomCount = 0, element = $('#testTop').get(0)
+
+        $('#testTop').on('tap', function(){
+          topCount++
+          $('#testTop').hide()
+        }).on('click', function(){
+          topCount++
+          $('#testTop').hide()
+        })
+
+        $('#test').on('click', function(){
+          bottomCount++
+        })
+
+        t.pause()
+        setTimeout(function(){
+          t.resume(function(){
+            t.assertEqual(1, topCount)
+            t.assertEqual(0, bottomCount)
+            $('#testTop').off()
+            $('#testTop').remove()
+          })
+        }, 5000)
+      }
+
+    })
+
+  })()
+  </script>
+</body>
+</html>

--- a/test/touch_manual.html
+++ b/test/touch_manual.html
@@ -55,6 +55,8 @@
           topCount++
           $('#testTop').hide()
         }).on('click', function(){
+	  // The Click handler is not required as it doesn't get fired, but is left
+	  // here to show it doesn't get fired.
           topCount++
           $('#testTop').hide()
         })
@@ -71,7 +73,7 @@
             $('#testTop').off()
             $('#testTop').remove()
           })
-        }, 5000)
+        }, 3000)
       }
 
     })


### PR DESCRIPTION
Issue '"tap" event bug; triggering click after on anything that is in the coordinate range.'
https://github.com/madrobby/zepto/issues/511
states in a comment from @madrobby that a test is needed to show what the problem is.

I have created a test to show the following:
 - when a 'tap' event is fired on an element and that element is moved away during the 'tap' event
 - then a 'click' event will be fired on an element that is underneath where the original element was.

Run the test on an Android device/simulator or iOS device/simulator and it will fail. Run it on a desktop browser and it will be fine.

The test requires manual intervention (you have to click the red box) - this is why I have put it into it's own file. The up/down/fire functions that are used by other touch tests do not illustrate this problem.

The reason for the problem is that mobile browser will fire both the tap and click events. The tap gets fired first, with the click fired shortly after.