### PR TITLE
Fix Firefox 20.0 "transitionend" handler

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -14,7 +14,7 @@
 
   function dasherize(str) { return downcase(str.replace(/([a-z])([A-Z])/, '$1-$2')) }
   function downcase(str) { return str.toLowerCase() }
-  function normalizeEvent(name) { return eventPrefix ? eventPrefix + name : downcase(name) }
+  function normalizeEvent(name) { return downcase(name) + (eventPrefix ? ' ' + eventPrefix + name : '') }
 
   $.each(vendors, function(vendor, event){
     if (testEl.style[vendor + 'TransitionProperty'] !== undefined) {


### PR DESCRIPTION
when there is no effcient detector for event support, monitor standard with compatible event type.
#741 fixed
