### PR TITLE
Allow for a jQuery-style custom data hash to be passed to the event listening functions

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -288,6 +288,8 @@ var Zepto = (function() {
 
   $.camelCase = camelize
   $.trim = function(str) { return str.trim() }
+  // why u no have noop?
+  $.noop = function() {}
 
   // plugin compatibility
   $.uuid = 0

--- a/test/event.html
+++ b/test/event.html
@@ -78,7 +78,7 @@
 
     Evidence('EventTest', {
       setUp: function(){
-        this.el = $('<div />').appendTo('#fixtures')
+        this.el = $('<div><span></span></div>').appendTo('#fixtures')
       },
 
       tearDown: function(){
@@ -106,6 +106,25 @@
         click(this.el)
         t.assertEqual('a b', log.sort().join(' '))
       },
+
+      testOnWithDataAndSelector: function(t) {
+        var log = []
+        this.el.on('click', 'span', {foo: 'bar'}, function(e) {
+          log.push(e.data.foo)
+        })
+        click(this.el.find('span'))
+        t.assertEqual('bar', log[0])
+      },
+
+      testOnWithDataNoSelector: function(t) {
+        var log = []
+        this.el.on('click', {bar: 'baz'}, function(e) {
+          log.push(e.data.bar)
+        })
+        click(this.el)
+        t.assertEqual('baz', log[0])
+      },
+
 
       testOnWithNullSelector: function(t){
         var log = []
@@ -140,7 +159,7 @@
           target = e.target
           currentTarget = e.currentTarget
         })
-        click($('<span>').appendTo(this.el))
+        click(this.el.find('span'))
         t.assertEqual('click', type)
         t.assertIdentical(this.el.find('span').get(0), target)
         t.assertIdentical(this.el.get(0), currentTarget)

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -2328,6 +2328,29 @@
         t.assertEqual(40, e5.keyCode)
       },
 
+      testOneCustomData: function(t){
+        var eventData, handler = function (e) {
+          eventData = e.data;
+        }
+        
+        $('#another_element')
+          .one('click', {customKey: 20}, handler)
+          .trigger('click')
+          
+        t.assertEqual(eventData.customKey, 20);
+      },
+
+      testLiveCustomData: function(t){
+        var eventData, handler = function (e) {
+          eventData = e.data
+        }
+
+        $('body p').live('click', {customKey: 40}, handler)
+        click($('p').get(0))
+
+        t.assertEqual(eventData.customKey, 40)
+      },
+
       testTriggerObject: function(t){
         var el = $('#some_element'),
             eventType, eventCode


### PR DESCRIPTION
In order to use Zepto with [sudo.js](https://github.com/taskrabbit/sudojs) the jQuery style custom-data-hash-for-events needs to be supported. I found the previous PR for this feature but, given the time-lapse, felt it better to submit a fresh one with what is perhaps a better stylistic fit.

All tests pass and a few have been added to both event.html as well as zepto.html 
