### PR TITLE
Include array indexes in $.param()

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -292,12 +292,12 @@
   var escape = encodeURIComponent
 
   function serialize(params, obj, traditional, scope){
-    var type, array = $.isArray(obj)
+    var type, objIsArray = $.isArray(obj), objIsObject = $.isPlainObject(obj) 
     $.each(obj, function(key, value) {
       type = $.type(value)
-      if (scope) key = traditional ? scope : scope + '[' + key + ']'
+      if (scope) key = traditional ? scope : scope + '[' + (objIsObject || type == 'object' || type == 'array' ? key : '') + ']'
       // handle data in serializeArray() format
-      if (!scope && array) params.add(value.name, value.value)
+      if (!scope && objIsArray) params.add(value.name, value.value)
       // recurse into nested objects
       else if (type == "array" || (!traditional && type == "object"))
         serialize(params, value, traditional, key)

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -744,7 +744,7 @@
       testDataOptionIsConvertedToSerializedForm: function(t) {
         $.ajax({ data: {hello: 'world', array: [1,2,3], object: { prop1: 'val', prop2: 2 } } })
         MockXHR.last.data = decodeURIComponent(MockXHR.last.data)
-        t.assertEqual('hello=world&array[0]=1&array[1]=2&array[2]=3&object[prop1]=val&object[prop2]=2', MockXHR.last.data)
+        t.assertEqual('hello=world&array[]=1&array[]=2&array[]=3&object[prop1]=val&object[prop2]=2', MockXHR.last.data)
       },
 
       testDataOptionIsConvertedToSerializedTraditionalForm: function(t) {
@@ -1000,7 +1000,7 @@
       testParamMethod: function(t) {
         var result = $.param({ libs: ['jQuery', 'script.aculo.us', 'Prototype', 'Dojo'] })
         result = decodeURIComponent(result)
-        t.assertEqual(result, "libs[0]=jQuery&libs[1]=script.aculo.us&libs[2]=Prototype&libs[3]=Dojo")
+        t.assertEqual(result, "libs[]=jQuery&libs[]=script.aculo.us&libs[]=Prototype&libs[]=Dojo")
 
         result = $.param({ jquery: 'Javascript', rails: 'Ruby', django: 'Python' })
         result = decodeURIComponent(result)
@@ -1012,7 +1012,7 @@
           capitals: { ecuador: 'Quito', austria: 'Vienna', GB: { england: 'London', scotland: 'Edinburgh'} }
         })
         result = decodeURIComponent(result)
-        t.assertEqual(result, "title=Some+Countries&list[0]=Ecuador&list[1]=Austria&list[2]=England&capitals[ecuador]=Quito&capitals[austria]=Vienna&capitals[GB][england]=London&capitals[GB][scotland]=Edinburgh")
+        t.assertEqual(result, "title=Some+Countries&list[]=Ecuador&list[]=Austria&list[]=England&capitals[ecuador]=Quito&capitals[austria]=Vienna&capitals[GB][england]=London&capitals[GB][scotland]=Edinburgh")
       },
 
       testParamEscaping: function(t) {
@@ -1031,7 +1031,33 @@
         }
         var result = $.param(data)
         result = decodeURIComponent(result)
-        t.assertEqual("a[0]=b&a[1]=c&a[2][d]=e&a[2][f][0]=g&a[2][f][1]=h", result)
+        t.assertEqual("a[]=b&a[]=c&a[2][d]=e&a[2][f][]=g&a[2][f][]=h", result)
+      },
+
+      testParamComplexNested: function(t) {
+        var data = {
+          x: [
+            [1, { attr1: 2 } ],
+            3,
+            { attr1: 4 },
+            { attr1: 5, attr2: [ 6 ] },
+            [ 7, [8, 9] ],
+            { attr1: { attr2: [ [ 10 ] ] } }
+          ]
+        }
+        var result = $.param(data)
+        result = decodeURIComponent(result)
+        t.assertEqual(
+          "x[0][]=1&"+
+          "x[0][1][attr1]=2&"+
+          "x[]=3&"+
+          "x[2][attr1]=4&"+
+          "x[3][attr1]=5&"+
+          "x[3][attr2][]=6&"+
+          "x[4][]=7&"+
+          "x[4][1][]=8&"+
+          "x[4][1][]=9&"+
+          "x[5][attr1][attr2][0][]=10", result)
       },
 
       testParamShallow: function(t) {


### PR DESCRIPTION
#208 rewrote support for key[] support inside $.param(), but it doesn't work if you have objects inside arrays:

Consider the case of:

```
var[][a]=1&var[][b]=2&var[][c]=3
```

It is ambiguous whether the var[][b] belongs to the [a] object, the [c] object or is an object on its own. PHP at least treats it as a totally new object which means it is impossible to have an array with objects with multiple values. jQuery gets around this by always including the array index, so the above example would become (assuming the [b] belonged to the same object as the [a]):

```
var[0][a]=1&var[0][b]=2&var[1][c]=3
```

Demonstration fiddles:
http://jsfiddle.net/DQD3c/1/  (jquery)
http://jsfiddle.net/DQD3c/2/  (zepto)

Attached patch adds the array index back in & updates test cases. traditional argument passing doesn't change, as mentioned in #208 it can't handle nested items anyway.
