### PR TITLE
Fix examples for calling `$.os.version` and `$.browser.version`

### DIFF
--- a/detect/_posts/1900-01-01-detect.md
+++ b/detect/_posts/1900-01-01-detect.md
@@ -38,6 +38,6 @@ $.browser.playbook
 !!$.os.phone         // => true
 !!$.os.iphone        // => true
 !!$.os.ios           // => true
-!!$.os.version       // => "6.1"
-!!$.browser.version  // => "536.26"
+$.os.version       // => "6.1"
+$.browser.version  // => "536.26"
 {% endhighlight %}


### PR DESCRIPTION
The examples were incorrect and turned the values into a boolean. The new examples will respond with strings as expected.
