### PR TITLE
Removes odd and unncessary use of , null, null, null, null, null, null, null, null, null, null, null, null in event.initEvent(type, bubbles, true)

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -240,7 +240,7 @@
     if (typeof type != 'string') props = type, type = props.type
     var event = document.createEvent(specialEvents[type] || 'Events'), bubbles = true
     if (props) for (var name in props) (name == 'bubbles') ? (bubbles = !!props[name]) : (event[name] = props[name])
-    event.initEvent(type, bubbles, true, null, null, null, null, null, null, null, null, null, null, null, null)
+    event.initEvent(type, bubbles, true)
     event.isDefaultPrevented = function(){ return this.defaultPrevented }
     return event
   }


### PR DESCRIPTION
Almost at the very bottom of event.js an $.Event function that issues events to the browser window using initEvent. The initEvent looked like: 

```
event.initEvent(type, bubbles, true, null, null, null, null, null, null, null, null, null, null, null, null)
```

I removed and ran tests and everything still passed.

This null x 12 as far as I can tell is unnecessary and distracting.
