### PR TITLE
AJAX2

### DIFF
--- a/src/ajax2.js
+++ b/src/ajax2.js
@@ -264,7 +264,7 @@
             parts = url.split(/\s/),
             selector,
             options = parseArguments(url, data, done),
-            callback = options.success
+            callback = options.done
         if (parts.length > 1) options.url = parts[0], selector = parts[1]
         options.done = function (response) {
             self.html(selector ?

--- a/src/ajax2.js
+++ b/src/ajax2.js
@@ -230,14 +230,14 @@
         return zeptoXHR
     }
 
-    // handle optional data/success arguments
-    function parseArguments(url, data, success, responseType) {
+    // handle optional data/done arguments
+    function parseArguments(url, data, done, responseType) {
         var hasData = !$.isFunction(data)
         return {
             url: url,
             data: hasData ? data : undefined,
-            success: !hasData ? data : $.isFunction(success) ? success : undefined,
-            responseType: hasData ? responseType || success : success
+            done: !hasData ? data : $.isFunction(done) ? done : undefined,
+            responseType: hasData ? responseType || done : done
         }
     }
 
@@ -253,7 +253,7 @@
 
     $.getJSON = function (url, data, done) {
         var options = parseArguments.apply(null, arguments)
-        // Not yet supported by any browsers
+        // Currently only supported by Firefox and Chrome dev
         options.responseType = 'json'
         return $.ajax(options)
     }

--- a/src/ajax2.js
+++ b/src/ajax2.js
@@ -1,0 +1,294 @@
+;(function ($) {
+    var document = window.document,
+        key,
+        name,
+        rscript = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi
+        //scriptTypeRE = /^(?:text|application)\/javascript/i,
+        //xmlTypeRE = /^(?:text|application)\/xml/i,
+        //jsonType = 'application/json',
+        //htmlType = 'text/html',
+        //blankRE = /^\s*$/
+
+    // Number of active Ajax requests
+    $.active = 0
+
+    // Empty function, used as default callback
+    function empty() {}
+
+    $.ajaxSettings = {
+        // Default type of request
+        type: 'GET',
+        // Default response type
+        responseType: 'text',
+        // Callback that is executed before request
+        beforeSend: empty,
+        // Callback that is executed if the request succeeds
+        done: empty,
+        // Callback that is executed the request fails
+        fail: empty,
+        // Callback that is executed on request complete (both: error and success)
+        always: empty,
+        // The context for the callbacks
+        context: null,
+        // Whether to trigger "global" Ajax events
+        global: true,
+        // Transport (XHR2)
+        xhr: function () {
+            return new window.XMLHttpRequest()
+        },
+        // Request headers
+        headers: {},
+        // Default timeout
+        timeout: 0,
+        // Whether data should be serialized to string
+        processData: true,
+        // Whether the browser should be allowed to cache GET responses
+        cache: true,
+        // Whether credential data should be sent with cross-domain requests
+        withCredentials: false,
+        // The username for same origin requests
+        username: null,
+        // The password for same origin requests
+        password: null
+    }
+
+    function appendQuery(url, query) {
+        return (url + '&' + query).replace(/[&?]{1,2}/, '?')
+    }
+
+    // serialize payload and append it to the URL for GET requests
+    // do not serialize if we have an acceptable object type
+    function serializeData(options) {
+        if (options.data instanceof File ||
+            options.data instanceof Blob ||
+            options.data instanceof Document ||
+            options.data instanceof FormData ||
+            options.data instanceof ArrayBuffer)
+            return
+        if (options.processData && options.data && $.type(options.data) != "string")
+            options.data = $.param(options.data, options.traditional)
+        if (options.data && (!options.type || options.type.toUpperCase() == 'GET'))
+            options.url = appendQuery(options.url, options.data)
+    }
+
+    $.ajax = function (options) {
+        var settings = $.extend({}, options || {})
+        for (key in $.ajaxSettings) if (settings[key] === undefined) settings[key] = $.ajaxSettings[key]
+
+        if (!settings.url) settings.url = window.location.toString()
+        serializeData(settings)
+        if (settings.cache === false) settings.url = appendQuery(settings.url, '_=' + Date.now())
+
+        var baseHeaders = {},
+            protocol = /^([\w-]+:)\/\//.test(settings.url) ? RegExp.$1 : window.location.protocol,
+            xhr = settings.xhr(),
+            abortTimeout
+
+        baseHeaders['X-Requested-With'] = 'XMLHttpRequest'
+
+        settings.headers = $.extend(baseHeaders, settings.headers || {})
+
+        // Create a zepto object from the xhr object
+        var zeptoXHR = $(xhr)
+
+        // Add function for upload progress hooking
+        zeptoXHR.uploadProgress = function(func){
+            if (typeof func !== 'function') throw TypeError('Expected func to be of type function.')
+            var callback = func
+            var context = settings.context
+            $(xhr.upload).on('progress', function(e){
+                callback.call(context, e, xhr)
+            })
+
+            // Return the zepto object for chaining
+            return this
+        }
+
+        // Add function for done hooking
+        zeptoXHR.done = function(func){
+            if (typeof func !== 'function') throw TypeError('Expected func to be of type function.')
+            var callback = func
+            var context = settings.context
+            $(xhr).on('load', function(e){
+                if ( !((this.status >= 200 && this.status < 300) || this.status == 304 || (this.status == 0 && protocol == 'file:')) ) {
+                    $(this).trigger($.Event('error', e))
+                    e.stopImmediatePropagation()
+                } else if (this.response == null) {
+                    $(this).trigger($.Event('error', e))
+                    e.stopImmediatePropagation()
+                } else {
+                    callback.call(context, this.response, this.statusText, this);
+                }
+            })
+
+            // Return the zepto object for chaining
+            return this
+        }
+
+        // Add function for fail hooking
+        zeptoXHR.fail = function(func){
+            if (typeof func !== 'function') throw TypeError('Expected func to be of type function.')
+            var callback = func
+            var context = settings.context
+            $(xhr).on('error timeout abort', function(e){
+                callback.call(context, e.type, this, settings)
+            })
+
+            // Return the zepto object for chaining
+            return this
+        }
+
+        // Add function for always hooking
+        zeptoXHR.always = function(func){
+            if (typeof func !== 'function') throw TypeError('Expected func to be of type function.')
+            var callback = func
+            var context = settings.context
+            $(xhr).on('loadend', function(e){
+                callback.call(context, this, settings)
+            })
+
+            // Return the zepto object for chaining
+            return this
+        }
+        
+        // If settings.global is set to true then hook in global ajax events
+        if (settings.global){
+            zeptoXHR.on('beforesend', function(e){
+                $(settings.context || document).trigger($.Event('ajaxBeforeSend'), [this, settings])
+            })
+
+            zeptoXHR.on('loadstart', function(e){
+                $(settings.context || document).trigger($.Event('ajaxStart'), [this, settings])
+            })
+
+            zeptoXHR.on('load', function(e){
+                if ( !((this.status >= 200 && this.status < 300) || this.status == 304 || (this.status == 0 && protocol == 'file:')) ) {
+                    $(this).trigger($.Event('error', e))
+                    e.stopImmediatePropagation()
+                } else if (this.response == null) {
+                    $(this).trigger($.Event('error', e))
+                    e.stopImmediatePropagation()
+                } else {
+                    $(settings.context || document).trigger($.Event('ajaxSuccess'), [this, settings, this.response])
+                }
+            })
+
+            zeptoXHR.on('error timeout abort', function(e){
+                $(settings.context || document).trigger($.Event('ajaxError'), [this, settings, e.type])
+            })
+
+            zeptoXHR.on('loadend', function(e){
+                $(settings.context || document).trigger($.Event('ajaxStop'), [this, settings])
+            })
+        }
+
+        // Hook active request count
+        zeptoXHR.on('loadstart', function(){
+            $.active++
+        })
+        zeptoXHR.on('loadend', function(){
+            $.active--
+        })
+
+        // Hook beforeSend
+        zeptoXHR.on('beforesend', function(){
+            settings.beforeSend.call(settings.context, xhr, settings)
+        })
+
+        // Now hook in done, fail and always functions
+        zeptoXHR.done(settings.done)
+        zeptoXHR.fail(settings.fail)
+        zeptoXHR.always(settings.always)
+
+        xhr.open(settings.type, settings.url, true, settings.username, settings.password)
+
+        // Set xhr fields
+        xhr.withCredentials = settings.withCredentials
+        xhr.responseType = settings.responseType
+        xhr.timeout = settings.timeout
+
+        // Add headers
+        for (name in settings.headers) xhr.setRequestHeader(name, settings.headers[name])
+
+        // Trigger beforeSend and check to make sure the request wasn't canceled
+        var beforeSendEvent = $.Event('beforesend')
+        zeptoXHR.trigger(beforeSendEvent)
+        if (beforeSendEvent.defaultPrevented === true) {
+            xhr.abort()
+            return false
+        }
+
+        // avoid sending empty string (#319)
+        xhr.send(settings.data ? settings.data : null)
+        return zeptoXHR
+    }
+
+    // handle optional data/success arguments
+    function parseArguments(url, data, success, dataType) {
+        var hasData = !$.isFunction(data)
+        return {
+            url: url,
+            data: hasData ? data : undefined,
+            success: !hasData ? data : $.isFunction(success) ? success : undefined,
+            dataType: hasData ? dataType || success : success
+        }
+    }
+
+    $.get = function (url, data, success, dataType) {
+        return $.ajax(parseArguments.apply(null, arguments))
+    }
+
+    $.post = function (url, data, success, dataType) {
+        var options = parseArguments.apply(null, arguments)
+        options.type = 'POST'
+        return $.ajax(options)
+    }
+
+    $.getJSON = function (url, data, success) {
+        var options = parseArguments.apply(null, arguments)
+        options.dataType = 'json'
+        return $.ajax(options)
+    }
+
+    $.fn.load = function (url, data, success) {
+        if (!this.length) return this
+        var self = this,
+            parts = url.split(/\s/),
+            selector,
+            options = parseArguments(url, data, success),
+            callback = options.success
+        if (parts.length > 1) options.url = parts[0], selector = parts[1]
+        options.success = function (response) {
+            self.html(selector ?
+                $('<div>').html(response.replace(rscript, "")).find(selector) : response)
+            callback && callback.apply(self, arguments)
+        }
+        $.ajax(options)
+        return this
+    }
+
+    var escape = encodeURIComponent
+
+    function serialize(params, obj, traditional, scope) {
+        var type, array = $.isArray(obj)
+            $.each(obj, function (key, value) {
+                type = $.type(value)
+                if (scope) key = traditional ? scope : scope + '[' + (array ? '' : key) + ']'
+                // handle data in serializeArray() format
+                if (!scope && array) params.add(value.name, value.value)
+                // recurse into nested objects
+                else if (type == "array" || (!traditional && type == "object"))
+                    serialize(params, value, traditional, key)
+                else params.add(key, value)
+            })
+    }
+
+    $.param = function (obj, traditional) {
+        var params = []
+        params.add = function (k, v) {
+            this.push(escape(k) + '=' + escape(v))
+        }
+        serialize(params, obj, traditional)
+        return params.join('&').replace(/%20/g, '+')
+    }
+})(Zepto)

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -29,7 +29,7 @@
           }
 
           function resumeOnAjaxError(t) {
-              $(document).on('ajaxError', function (xhr, settings, e) {
+              $(document).on('ajaxError', function (e, xhr, settings, err) {
                   deferredResume(t, function () {
                       t.assert(false, "request errored out: " + xhr.responseText)
                   })
@@ -535,7 +535,7 @@
               }
           }
 
-          Evidence('ZeptoAjaxTest2', {
+          Evidence('ZeptoAjax2Test2', {
               setUp: function () {
                   $.ajaxSettings.xhr = function () { return new MockXHR }
               },
@@ -718,14 +718,14 @@
 
               testGlobalBeforeSendAbort: function (t) {
                   var xhr
-                  $(document).on('ajaxBeforeSend', function (x, s) { xhr = x; return false })
+                  $(document).on('ajaxBeforeSend', function (e, x, s) { xhr = x; return false })
                   t.assertFalse($.ajax())
                   t.assert(xhr.aborted)
               },
 
               testGlobalAjaxStartCantAbort: function (t) {
                   var xhr
-                  $(document).on('ajaxStart', function (x, s) { xhr = x; return false })
+                  $(document).on('ajaxStart', function (e, x, s) { xhr = x; return false })
                   t.assert($.ajax())
                   t.assert(!xhr.aborted)
               },
@@ -814,7 +814,7 @@
               }
           })
 
-          Evidence('ZeptoAjaxHelperMethodsTest', {
+          Evidence('ZeptoAjax2HelperMethodsTest', {
 
               testParamMethod: function (t) {
                   var result = $.param({ libs: ['jQuery', 'script.aculo.us', 'Prototype', 'Dojo'] })

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -107,7 +107,7 @@
                           that.testCase.resume(function () {
                               if (fn) fn.apply(context, args)
                           })
-                      }, 5)
+                      }, 50)
                   })
               },
               handlers: function () {

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -162,8 +162,9 @@
                       url: 'fixtures/ajax_load_simple.html',
                       done: t.reg.handler('done'),
                       fail: t.reg.handler('fail'),
-                      always: t.reg.resumeHandler('always', function () {
+                      always: t.reg.handler('always', function () {
                           t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess always ajaxStop', t.reg.events())
+                          t.resume()
                       })
                   })
                   t.assert($.isFunction(zeptoXhr[0].getResponseHeader))
@@ -502,8 +503,8 @@
               send: function (data) {
                   this.data = data
                   this.dispatchEvent($.event('loadstart'))
-                  if (this.timeout != 0){
-                      setTimeout(function(){
+                  if (this.timeout != 0) {
+                      setTimeout(function () {
                           this.aborted = true
                           this.dispatchEvent($.event('timeout'))
                       }, this.timeout)
@@ -518,9 +519,9 @@
                   this.statusText = '200 OK'
                   this.responseText = this.response = responseText
                   $.extend(this.responseHeaders, headers)
-                  if ( !((this.status >= 200 && this.status < 300) || this.status == 304)){
+                  if (!((this.status >= 200 && this.status < 300) || this.status == 304)) {
                       this.dispatchEvent($.event('error'))
-                  }else{
+                  } else {
                       this.dispatchEvent($.event('load'))
                   }
                   this.onreadystatechange()

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -142,11 +142,11 @@
               }
           })
 
-          Evidence('ZeptoAjaxTest', {
+          Evidence('ZeptoAjax2Test', {
 
               setUp: function () {
                   var reg = new CallbackRegistry(this),
-                  globals = toArray('ajaxBeforeSend ajaxSend ajaxSuccess ajaxError ajaxComplete')
+                  globals = toArray('ajaxBeforeSend ajaxStart ajaxSuccess ajaxError ajaxStop')
 
                   $(document).on(reg.handlers.apply(reg, globals))
                   this.reg = reg
@@ -160,10 +160,10 @@
                   t.pause()
                   var xhr = $.ajax({
                       url: 'fixtures/ajax_load_simple.html',
-                      success: t.reg.handler('success'),
-                      error: t.reg.handler('error'),
-                      complete: t.reg.resumeHandler('complete', function () {
-                          t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess complete ajaxComplete', t.reg.events())
+                      done: t.reg.handler('done'),
+                      fail: t.reg.handler('fail'),
+                      always: t.reg.resumeHandler('always', function () {
+                          t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess always ajaxStop', t.reg.events())
                       })
                   })
                   t.assert($.isFunction(xhr.getResponseHeader))
@@ -171,17 +171,17 @@
 
               testAjaxGet: function (t) {
                   t.pause()
-                  var xhr = $.get('echo', t.reg.resumeHandler('success', function (response) {
+                  var xhr = $.get('echo', t.reg.resumeHandler('done', function (response) {
                       t.assertIdentical(window, this)
                       t.assertLine("GET ?{}", response)
-                      t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                      t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess ajaxStop', t.reg.events())
                   }))
                   t.assertIn('abort', xhr)
               },
 
               testAjaxGetWithParams: function (t) {
                   t.pause()
-                  $.get('echo', { sample: 'data' }, t.reg.resumeHandler('success', function (response) {
+                  $.get('echo', { sample: 'data' }, t.reg.resumeHandler('done', function (response) {
                       t.assertLine('GET ?{"sample":"data"}', response)
                       t.assertLine("accept: */*", response)
                   }))
@@ -189,7 +189,7 @@
 
               testAjaxGetWithParamsAndType: function (t) {
                   t.pause()
-                  $.get('echo', { sample: 'data' }, t.reg.resumeHandler('success', function (response) {
+                  $.get('echo', { sample: 'data' }, t.reg.resumeHandler('done', function (response) {
                       t.assertLine('GET ?{"sample":"data"}', response)
                       t.assertLine("accept: text/plain", response)
                   }), 'text')
@@ -201,7 +201,7 @@
                       deferredResume(t, function () {
                           t.assertLine('GET ?{"sample":"data"}', response)
                           t.assertLine("accept: text/plain", response)
-                          t.assertEqualList('ajaxBeforeSend ajaxSend ajaxSuccess ajaxComplete', t.reg.events())
+                          t.assertEqualList('ajaxBeforeSend ajaxStart ajaxSuccess ajaxStop', t.reg.events())
                       })
                   })
                   $.get('echo', { sample: 'data' }, 'text')
@@ -209,12 +209,12 @@
 
               testAjaxPost: function (t) {
                   t.pause()
-                  var xhr = $.post('echo', t.reg.resumeHandler('success', function (response) {
+                  var xhr = $.post('echo', t.reg.resumeHandler('done', function (response) {
                       t.assertIdentical(window, this)
                       t.assertLine("POST ?{}", response)
                       t.assertLine("accept: */*", response)
                       t.assertLine('{}', response)
-                      t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                      t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess ajaxStop', t.reg.events())
                   }))
                   t.assertIn('abort', xhr)
               },
@@ -222,7 +222,7 @@
               testAjaxPostWithPayloadAndType: function (t) {
                   t.pause()
                   var payload = { sample: 'data' }
-                  $.post('echo', payload, t.reg.resumeHandler('success', function (response) {
+                  $.post('echo', payload, t.reg.resumeHandler('done', function (response) {
                       t.assertLine("content-type: application/x-www-form-urlencoded", response)
                       t.assertLine("accept: text/plain", response)
                       t.assertLine('{"sample":"data"}', response)
@@ -234,11 +234,11 @@
                   t.assertIdentical(0, $.active, 'initial count mismatch')
                   $(document)
                 .on('ajaxStart', function () { ajaxStarted++ })
-                .on('ajaxEnd', function () { ajaxEnded++ })
-                .on('ajaxSend', function () {
+                .on('ajaxStop', function () { ajaxEnded++ })
+                .on('ajaxStart', function () {
                     if ($.active > maxActive) maxActive = $.active
                 })
-                .on('ajaxComplete', function () {
+                .on('ajaxStop', function () {
                     if (++requestsCompleted == 3)
                         deferredResume(t, function () {
                             this.assertEqual(3, maxActive)
@@ -259,7 +259,7 @@
                   $.ajax({
                       url: 'json',
                       headers: { accept: 'application/json' },
-                      success: t.reg.resumeHandler('success', function (data) {
+                      success: t.reg.resumeHandler('done', function (data) {
                           t.assertEqual('world', data.hello)
                       })
                   })
@@ -271,10 +271,10 @@
 
                   var xhr = $.getJSON(
                 'json',
-                t.reg.resumeHandler('success', function (data) {
+                t.reg.resumeHandler('done', function (data) {
                     t.assertEqual('world', data.hello)
                     t.assert($.isEmptyObject(data.query))
-                    t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                    t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess ajaxStop', t.reg.events())
                 })
               )
                   t.assertIn('abort', xhr)
@@ -286,7 +286,7 @@
 
                   $.getJSON(
                 'json', { sample: 'data' },
-                t.reg.resumeHandler('success', function (data) {
+                t.reg.resumeHandler('done', function (data) {
                     t.assertEqual('data', data.query.sample)
                 }),
                 'text' // ignored
@@ -298,7 +298,7 @@
                   var xhr = $.ajax({
                       url: 'echo',
                       cache: false,
-                      success: t.reg.resumeHandler('success', function (response) {
+                      done: t.reg.resumeHandler('done', function (response) {
                           // check that the no-cache param (or an element of it) looks like a timestamp
                           t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
                       })
@@ -311,7 +311,7 @@
                       url: 'echo',
                       data: { data: 'sample' },
                       cache: false,
-                      success: t.reg.resumeHandler('success', function (response) {
+                      done: t.reg.resumeHandler('done', function (response) {
                           // check that the no-cache param (or an element of it) looks like a timestamp
                           t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
                       })
@@ -324,7 +324,7 @@
                       url: 'echo',
                       data: { _: 'test' },
                       cache: false,
-                      success: t.reg.resumeHandler('success', function (response) {
+                      done: t.reg.resumeHandler('done', function (response) {
                           // check that the no-cache param (or an element of it) looks like a timestamp
                           t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
                       })
@@ -337,7 +337,7 @@
                       url: 'echo',
                       data: { _: 'test', data: 'sample' },
                       cache: false,
-                      success: t.reg.resumeHandler('success', function (response) {
+                      done: t.reg.resumeHandler('done', function (response) {
                           // check that the no-cache param (or an element of it) looks like a timestamp
                           t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
                       })
@@ -349,13 +349,13 @@
                   var testEl = $('#ajax_load')
                   var el = testEl.load(
                 'fixtures/ajax_load_simple.html',
-                t.reg.resumeHandler('success', function (response, status, xhr) {
+                t.reg.resumeHandler('done', function (response, statusText, xhr) {
                     t.assertIdentical(testEl, this)
                     t.assertEqual("simple ajax load\n", response)
                     t.assertEqual('simple ajax load', testEl.html().trim())
-                    t.assertEqual('success', status)
+                    t.assertEqual('200 OK', statusText)
                     t.assertIn('abort', xhr)
-                    t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                    t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess ajaxStop', t.reg.events())
                 })
               )
                   t.assertIdentical(testEl, el)
@@ -366,7 +366,7 @@
                   var testEl = $('#ajax_load')
                   testEl.load(
                 'fixtures/ajax_load_selector.html #ajax_load_test_div',
-                t.reg.resumeHandler('success', function () {
+                t.reg.resumeHandler('done', function () {
                     t.assertEqual(
                     '<div id="ajax_load_test_div">ajax load with selector</div>',
                     testEl.html().trim()
@@ -406,11 +406,11 @@
                       url: 'fixtures/ajax_load_simple.html',
                       context: body,
                       beforeSend: t.reg.handler('beforeSend'),
-                      success: t.reg.handler('success'),
-                      complete: t.reg.resumeHandler('complete', function () {
+                      done: t.reg.handler('done'),
+                      always: t.reg.resumeHandler('always', function () {
                           t.assertIdentical(body, this)
                           t.assertIdentical(body, t.reg.context('beforeSend'))
-                          t.assertIdentical(body, t.reg.context('success'))
+                          t.assertIdentical(body, t.reg.context('done'))
                           t.assertIdentical(document.body, t.reg.target('ajaxBeforeSend'))
                           t.assertIdentical(document.body, t.reg.target('ajaxSuccess'))
                       })
@@ -424,11 +424,11 @@
                       url: 'fixtures/ajax_load_simple.html',
                       context: obj,
                       beforeSend: t.reg.handler('beforeSend'),
-                      success: t.reg.handler('success'),
-                      complete: t.reg.resumeHandler('complete', function () {
+                      done: t.reg.handler('done'),
+                      always: t.reg.resumeHandler('always', function () {
                           t.assertIdentical(obj, this)
                           t.assertIdentical(obj, t.reg.context('beforeSend'))
-                          t.assertIdentical(obj, t.reg.context('success'))
+                          t.assertIdentical(obj, t.reg.context('done'))
                           t.assertUndefined(t.reg.target('ajaxBeforeSend'))
                           t.assertUndefined(t.reg.target('ajaxSuccess'))
                       })

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -103,11 +103,11 @@
                   var that = this
                   return this.handler(name, function () {
                       var context = this, args = arguments
-                      setTimeout(function () {
+                      //setTimeout(function () {
                           that.testCase.resume(function () {
                               if (fn) fn.apply(context, args)
                           })
-                      }, 50)
+                      //}, 5)
                   })
               },
               handlers: function () {
@@ -163,9 +163,8 @@
                       beforeSend: t.reg.handler('beforeSend'),
                       done: t.reg.handler('done'),
                       fail: t.reg.handler('fail'),
-                      always: t.reg.handler('always', function () {
+                      always: t.reg.resumeHandler('always', function () {
                           t.assertEqualList('beforeSend ajaxBeforeSend ajaxStart done ajaxSuccess always ajaxStop', t.reg.events())
-                          t.resume()
                       })
                   })
                   t.assert($.isFunction(zeptoXhr[0].getResponseHeader))

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -25,7 +25,7 @@
       (function () {
 
           function deferredResume(t, fn) {
-              setTimeout(function () { t.resume(fn || function () { }) }, 5)
+              t.resume(fn || function () { })
           }
 
           function resumeOnAjaxError(t) {
@@ -157,7 +157,7 @@
               },
 
               testAjaxBase: function (t) {
-                  //t.pause()
+                  t.pause()
                   var zeptoXhr = $.ajax({
                       url: 'fixtures/ajax_load_simple.html',
                       beforeSend: t.reg.handler('beforeSend'),

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -158,7 +158,7 @@
 
               testAjaxBase: function (t) {
                   t.pause()
-                  var xhr = $.ajax({
+                  var zeptoXhr = $.ajax({
                       url: 'fixtures/ajax_load_simple.html',
                       done: t.reg.handler('done'),
                       fail: t.reg.handler('fail'),
@@ -166,17 +166,17 @@
                           t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess always ajaxStop', t.reg.events())
                       })
                   })
-                  t.assert($.isFunction(xhr.getResponseHeader))
+                  t.assert($.isFunction(zeptoXhr[0].getResponseHeader))
               },
 
               testAjaxGet: function (t) {
                   t.pause()
-                  var xhr = $.get('echo', t.reg.resumeHandler('done', function (response) {
+                  var zeptoXhr = $.get('echo', t.reg.resumeHandler('done', function (response) {
                       t.assertIdentical(window, this)
                       t.assertLine("GET ?{}", response)
                       t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess ajaxStop', t.reg.events())
                   }))
-                  t.assertIn('abort', xhr)
+                  t.assertIn('abort', zeptoXhr[0])
               },
 
               testAjaxGetWithParams: function (t) {
@@ -209,14 +209,14 @@
 
               testAjaxPost: function (t) {
                   t.pause()
-                  var xhr = $.post('echo', t.reg.resumeHandler('done', function (response) {
+                  var zeptoXhr = $.post('echo', t.reg.resumeHandler('done', function (response) {
                       t.assertIdentical(window, this)
                       t.assertLine("POST ?{}", response)
                       t.assertLine("accept: */*", response)
                       t.assertLine('{}', response)
                       t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess ajaxStop', t.reg.events())
                   }))
-                  t.assertIn('abort', xhr)
+                  t.assertIn('abort', zeptoXhr[0])
               },
 
               testAjaxPostWithPayloadAndType: function (t) {
@@ -259,7 +259,7 @@
                   $.ajax({
                       url: 'json',
                       headers: { accept: 'application/json' },
-                      success: t.reg.resumeHandler('done', function (data) {
+                      done: t.reg.resumeHandler('done', function (data) {
                           t.assertEqual('world', data.hello)
                       })
                   })
@@ -269,7 +269,7 @@
                   t.pause()
                   resumeOnAjaxError(t)
 
-                  var xhr = $.getJSON(
+                  var zeptoXhr = $.getJSON(
                 'json',
                 t.reg.resumeHandler('done', function (data) {
                     t.assertEqual('world', data.hello)
@@ -277,7 +277,7 @@
                     t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess ajaxStop', t.reg.events())
                 })
               )
-                  t.assertIn('abort', xhr)
+                  t.assertIn('abort', zeptoXhr[0])
               },
 
               testAjaxGetJSONWithParams: function (t) {
@@ -295,7 +295,7 @@
 
               testNoCacheParam: function (t) {
                   t.pause()
-                  var xhr = $.ajax({
+                  var zeptoXhr = $.ajax({
                       url: 'echo',
                       cache: false,
                       done: t.reg.resumeHandler('done', function (response) {
@@ -307,7 +307,7 @@
 
               testNoCacheParameterWithParam: function (t) {
                   t.pause()
-                  var xhr = $.ajax({
+                  var zeptoXhr = $.ajax({
                       url: 'echo',
                       data: { data: 'sample' },
                       cache: false,
@@ -320,7 +320,7 @@
 
               testNoCacheParameterAlreadyPresent: function (t) {
                   t.pause()
-                  var xhr = $.ajax({
+                  var zeptoXhr = $.ajax({
                       url: 'echo',
                       data: { _: 'test' },
                       cache: false,
@@ -333,7 +333,7 @@
 
               testNoCacheParameterAlreadyPresentWithParam: function (t) {
                   t.pause()
-                  var xhr = $.ajax({
+                  var zeptoXhr = $.ajax({
                       url: 'echo',
                       data: { _: 'test', data: 'sample' },
                       cache: false,

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -29,7 +29,7 @@
           }
 
           function resumeOnAjaxError(t) {
-              $(document).on('ajaxError', function (e, zeptoXhr) {
+              $(document).on('ajaxError', function (xhr, settings, e) {
                   deferredResume(t, function () {
                       t.assert(false, "request errored out: " + xhr.responseText)
                   })

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -157,13 +157,14 @@
               },
 
               testAjaxBase: function (t) {
-                  t.pause()
+                  //t.pause()
                   var zeptoXhr = $.ajax({
                       url: 'fixtures/ajax_load_simple.html',
+                      beforeSend: t.reg.handler('beforeSend'),
                       done: t.reg.handler('done'),
                       fail: t.reg.handler('fail'),
                       always: t.reg.handler('always', function () {
-                          t.assertEqualList('ajaxBeforeSend ajaxStart done ajaxSuccess always ajaxStop', t.reg.events())
+                          t.assertEqualList('beforeSend ajaxBeforeSend ajaxStart done ajaxSuccess always ajaxStop', t.reg.events())
                           t.resume()
                       })
                   })

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -1,0 +1,879 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+  <link rel="stylesheet" href="test.css">
+  <title>Zepto Ajax2 unit tests</title>
+  <script src="../vendor/evidence.js"></script>
+  <script src="evidence_runner.js"></script>
+  <script src="../src/polyfill.js"></script>
+  <script src="../src/zepto.js"></script>
+  <script src="../src/event.js"></script>
+  <script src="../src/ajax2.js"></script>
+</head>
+<body>
+  <h1>Zepto Ajax2 unit tests</h1>
+  <p id="results">
+    Running… see browser console for results
+  </p>
+  <div id="fixtures">
+    <div id="ajax_load"></div>
+  </div>
+
+  <script>
+      (function () {
+
+          function deferredResume(t, fn) {
+              setTimeout(function () { t.resume(fn || function () { }) }, 5)
+          }
+
+          function resumeOnAjaxError(t) {
+              $(document).on('ajaxError', function (e, zeptoXhr) {
+                  deferredResume(t, function () {
+                      t.assert(false, "request errored out: " + xhr.responseText)
+                  })
+              })
+          }
+
+          function toArray(list) {
+              if ($.type(list) == "string") return list.split(/(?:\s*,\s*|\s+)/)
+              else return list
+          }
+
+          Evidence.Assertions.assertEqualList = function (expected, actual, message) {
+              var expectedList = toArray(expected),
+                actualList = toArray(actual)
+
+              this._assertExpression(
+              expectedList.join(' ') == actualList.join(' '),
+              message || "Lists don't match.",
+              'Expected %o, got %o.', expectedList, actualList
+            )
+          }
+
+          Evidence.Assertions.assertLine = function (line, string, message) {
+              var lines = string.split("\n")
+
+              this._assertExpression(
+              $.inArray(line, lines) >= 0,
+              message || "Line not found.",
+              'Expected line %s in %s.', line, string
+            )
+          }
+
+          Evidence.Assertions.assertLinePattern = function (pattern, string, message) {
+              var lines = string.split("\n")
+
+              var i, match = false
+              if (lines.length) {
+                  for (i = 0; i < lines.length; i++) {
+                      if (lines[i].search(pattern) !== -1) {
+                          match = true
+                          break
+                      }
+                  }
+              }
+
+              this._assertExpression(
+              match === true,
+              message || "Pattern not found.",
+              'Expected pattern %s in %s.', pattern, string
+            )
+          }
+
+          var slice = [].slice
+
+          function CallbackRegistry(t) {
+              this.testCase = t
+              this.called = []
+          }
+          $.extend(CallbackRegistry.prototype, {
+              register: function (name, context, args) {
+                  this.called.push([name, context, args])
+              },
+              handler: function (name, fn) {
+                  var that = this
+                  return function () {
+                      that.register(name, this, slice.call(arguments))
+                      if (fn) return fn.apply(this, arguments)
+                  }
+              },
+              resumeHandler: function (name, fn) {
+                  var that = this
+                  return this.handler(name, function () {
+                      var context = this, args = arguments
+                      setTimeout(function () {
+                          that.testCase.resume(function () {
+                              if (fn) fn.apply(context, args)
+                          })
+                      }, 5)
+                  })
+              },
+              handlers: function () {
+                  var that = this, hash = {}
+                  $.each(arguments, function (i, name) {
+                      hash[name] = that.handler(name)
+                  })
+                  return hash
+              },
+              events: function () {
+                  return $.map(this.called, function (item) { return item[0] })
+              },
+              context: function (name) {
+                  return this.find(name, function (item) { return item[1] })
+              },
+              args: function (name) {
+                  return this.find(name, function (item) { return item[2] })
+              },
+              target: function (name) {
+                  var args = this.args(name)
+                  return args && args[0].target
+              },
+              find: function (name, fn) {
+                  var obj
+                  $.each(this.called, function (i, item) {
+                      if (item[0] == name) {
+                          obj = fn(item)
+                          return false
+                      }
+                  })
+                  return obj
+              }
+          })
+
+          Evidence('ZeptoAjaxTest', {
+
+              setUp: function () {
+                  var reg = new CallbackRegistry(this),
+                  globals = toArray('ajaxBeforeSend ajaxSend ajaxSuccess ajaxError ajaxComplete')
+
+                  $(document).on(reg.handlers.apply(reg, globals))
+                  this.reg = reg
+              },
+
+              tearDown: function () {
+                  $(document).off()
+              },
+
+              testAjaxBase: function (t) {
+                  t.pause()
+                  var xhr = $.ajax({
+                      url: 'fixtures/ajax_load_simple.html',
+                      success: t.reg.handler('success'),
+                      error: t.reg.handler('error'),
+                      complete: t.reg.resumeHandler('complete', function () {
+                          t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess complete ajaxComplete', t.reg.events())
+                      })
+                  })
+                  t.assert($.isFunction(xhr.getResponseHeader))
+              },
+
+              testAjaxGet: function (t) {
+                  t.pause()
+                  var xhr = $.get('echo', t.reg.resumeHandler('success', function (response) {
+                      t.assertIdentical(window, this)
+                      t.assertLine("GET ?{}", response)
+                      t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                  }))
+                  t.assertIn('abort', xhr)
+              },
+
+              testAjaxGetWithParams: function (t) {
+                  t.pause()
+                  $.get('echo', { sample: 'data' }, t.reg.resumeHandler('success', function (response) {
+                      t.assertLine('GET ?{"sample":"data"}', response)
+                      t.assertLine("accept: */*", response)
+                  }))
+              },
+
+              testAjaxGetWithParamsAndType: function (t) {
+                  t.pause()
+                  $.get('echo', { sample: 'data' }, t.reg.resumeHandler('success', function (response) {
+                      t.assertLine('GET ?{"sample":"data"}', response)
+                      t.assertLine("accept: text/plain", response)
+                  }), 'text')
+              },
+
+              testAjaxGetWithParamsAndTypeNoCallback: function (t) {
+                  t.pause()
+                  $(document).on('ajaxSuccess', function (e, xhr, settings, response) {
+                      deferredResume(t, function () {
+                          t.assertLine('GET ?{"sample":"data"}', response)
+                          t.assertLine("accept: text/plain", response)
+                          t.assertEqualList('ajaxBeforeSend ajaxSend ajaxSuccess ajaxComplete', t.reg.events())
+                      })
+                  })
+                  $.get('echo', { sample: 'data' }, 'text')
+              },
+
+              testAjaxPost: function (t) {
+                  t.pause()
+                  var xhr = $.post('echo', t.reg.resumeHandler('success', function (response) {
+                      t.assertIdentical(window, this)
+                      t.assertLine("POST ?{}", response)
+                      t.assertLine("accept: */*", response)
+                      t.assertLine('{}', response)
+                      t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                  }))
+                  t.assertIn('abort', xhr)
+              },
+
+              testAjaxPostWithPayloadAndType: function (t) {
+                  t.pause()
+                  var payload = { sample: 'data' }
+                  $.post('echo', payload, t.reg.resumeHandler('success', function (response) {
+                      t.assertLine("content-type: application/x-www-form-urlencoded", response)
+                      t.assertLine("accept: text/plain", response)
+                      t.assertLine('{"sample":"data"}', response)
+                  }), 'text')
+              },
+
+              testNumberOfActiveRequests: function (t) {
+                  var maxActive = 0, ajaxStarted = 0, ajaxEnded = 0, requestsCompleted = 0
+                  t.assertIdentical(0, $.active, 'initial count mismatch')
+                  $(document)
+                .on('ajaxStart', function () { ajaxStarted++ })
+                .on('ajaxEnd', function () { ajaxEnded++ })
+                .on('ajaxSend', function () {
+                    if ($.active > maxActive) maxActive = $.active
+                })
+                .on('ajaxComplete', function () {
+                    if (++requestsCompleted == 3)
+                        deferredResume(t, function () {
+                            this.assertEqual(3, maxActive)
+                            this.assertIdentical(0, $.active)
+                        })
+                })
+
+                  t.pause()
+                  $.ajax({ url: 'echo' })
+                  $.ajax({ url: 'echo' })
+                  $.ajax({ url: 'echo' })
+              },
+
+              testAjaxJSON: function (t) {
+                  t.pause()
+                  resumeOnAjaxError(t)
+
+                  $.ajax({
+                      url: 'json',
+                      headers: { accept: 'application/json' },
+                      success: t.reg.resumeHandler('success', function (data) {
+                          t.assertEqual('world', data.hello)
+                      })
+                  })
+              },
+
+              testAjaxGetJSON: function (t) {
+                  t.pause()
+                  resumeOnAjaxError(t)
+
+                  var xhr = $.getJSON(
+                'json',
+                t.reg.resumeHandler('success', function (data) {
+                    t.assertEqual('world', data.hello)
+                    t.assert($.isEmptyObject(data.query))
+                    t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                })
+              )
+                  t.assertIn('abort', xhr)
+              },
+
+              testAjaxGetJSONWithParams: function (t) {
+                  t.pause()
+                  resumeOnAjaxError(t)
+
+                  $.getJSON(
+                'json', { sample: 'data' },
+                t.reg.resumeHandler('success', function (data) {
+                    t.assertEqual('data', data.query.sample)
+                }),
+                'text' // ignored
+              )
+              },
+
+              testNoCacheParam: function (t) {
+                  t.pause()
+                  var xhr = $.ajax({
+                      url: 'echo',
+                      cache: false,
+                      success: t.reg.resumeHandler('success', function (response) {
+                          // check that the no-cache param (or an element of it) looks like a timestamp
+                          t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
+                      })
+                  })
+              },
+
+              testNoCacheParameterWithParam: function (t) {
+                  t.pause()
+                  var xhr = $.ajax({
+                      url: 'echo',
+                      data: { data: 'sample' },
+                      cache: false,
+                      success: t.reg.resumeHandler('success', function (response) {
+                          // check that the no-cache param (or an element of it) looks like a timestamp
+                          t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
+                      })
+                  })
+              },
+
+              testNoCacheParameterAlreadyPresent: function (t) {
+                  t.pause()
+                  var xhr = $.ajax({
+                      url: 'echo',
+                      data: { _: 'test' },
+                      cache: false,
+                      success: t.reg.resumeHandler('success', function (response) {
+                          // check that the no-cache param (or an element of it) looks like a timestamp
+                          t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
+                      })
+                  })
+              },
+
+              testNoCacheParameterAlreadyPresentWithParam: function (t) {
+                  t.pause()
+                  var xhr = $.ajax({
+                      url: 'echo',
+                      data: { _: 'test', data: 'sample' },
+                      cache: false,
+                      success: t.reg.resumeHandler('success', function (response) {
+                          // check that the no-cache param (or an element of it) looks like a timestamp
+                          t.assertLinePattern(/"_":(\[".*",)?"[\d]{13}"/g, response)
+                      })
+                  })
+              },
+
+              testAjaxLoad: function (t) {
+                  t.pause()
+                  var testEl = $('#ajax_load')
+                  var el = testEl.load(
+                'fixtures/ajax_load_simple.html',
+                t.reg.resumeHandler('success', function (response, status, xhr) {
+                    t.assertIdentical(testEl, this)
+                    t.assertEqual("simple ajax load\n", response)
+                    t.assertEqual('simple ajax load', testEl.html().trim())
+                    t.assertEqual('success', status)
+                    t.assertIn('abort', xhr)
+                    t.assertEqualList('ajaxBeforeSend ajaxSend success ajaxSuccess ajaxComplete', t.reg.events())
+                })
+              )
+                  t.assertIdentical(testEl, el)
+              },
+
+              testAjaxLoadWithSelector: function (t) {
+                  t.pause()
+                  var testEl = $('#ajax_load')
+                  testEl.load(
+                'fixtures/ajax_load_selector.html #ajax_load_test_div',
+                t.reg.resumeHandler('success', function () {
+                    t.assertEqual(
+                    '<div id="ajax_load_test_div">ajax load with selector</div>',
+                    testEl.html().trim()
+                  )
+                })
+              )
+              },
+
+              testAjaxLoadWithJavaScript: function (t) {
+                  var testEl = $('#ajax_load')
+                  t.pause()
+                  window.testValue = 0
+                  testEl.load('fixtures/ajax_load_selector_javascript.html', function () {
+                      deferredResume(t, function () {
+                          this.assertEqual(window.testValue, 1)
+                          delete window.testValue
+                      })
+                  })
+              },
+
+              testAjaxLoadWithSelectorAndJavaScript: function (t) {
+                  var testEl = $('#ajax_load')
+                  t.pause()
+                  window.testValue = 0
+                  testEl.load('fixtures/ajax_load_selector_javascript.html #ajax_load_test_div', function () {
+                      deferredResume(t, function () {
+                          this.assertEqual(window.testValue, 0)
+                          delete window.testValue
+                      })
+                  })
+              },
+
+              testAjaxWithContext: function (t) {
+                  t.pause()
+                  var body = $('body')
+                  $.ajax({
+                      url: 'fixtures/ajax_load_simple.html',
+                      context: body,
+                      beforeSend: t.reg.handler('beforeSend'),
+                      success: t.reg.handler('success'),
+                      complete: t.reg.resumeHandler('complete', function () {
+                          t.assertIdentical(body, this)
+                          t.assertIdentical(body, t.reg.context('beforeSend'))
+                          t.assertIdentical(body, t.reg.context('success'))
+                          t.assertIdentical(document.body, t.reg.target('ajaxBeforeSend'))
+                          t.assertIdentical(document.body, t.reg.target('ajaxSuccess'))
+                      })
+                  })
+              },
+
+              testAjaxWithContextPlainObject: function (t) {
+                  t.pause()
+                  var obj = {}
+                  $.ajax({
+                      url: 'fixtures/ajax_load_simple.html',
+                      context: obj,
+                      beforeSend: t.reg.handler('beforeSend'),
+                      success: t.reg.handler('success'),
+                      complete: t.reg.resumeHandler('complete', function () {
+                          t.assertIdentical(obj, this)
+                          t.assertIdentical(obj, t.reg.context('beforeSend'))
+                          t.assertIdentical(obj, t.reg.context('success'))
+                          t.assertUndefined(t.reg.target('ajaxBeforeSend'))
+                          t.assertUndefined(t.reg.target('ajaxSuccess'))
+                      })
+                  })
+              }
+          })
+
+          var OriginalXHR = $.ajaxSettings.xhr
+
+          function MockXHR() {
+              this.headers = []
+              this.responseHeaders = {}
+              this._listeners = {}
+              MockXHR.last = this
+          }
+          MockXHR.prototype = {
+              addEventListener: function (type, listener) {
+                  if (typeof this._listeners[type] == "undefined") {
+                      this._listeners[type] = []
+                  }
+
+                  this._listeners[type].push(listener)
+              },
+
+              dispatchEvent: function (event) {
+                  if (typeof event == "string") {
+                      event = { type: event }
+                  }
+                  if (!event.target) {
+                      event.target = this
+                  }
+
+                  if (!event.type) {  //falsy
+                      throw new Error("Event object missing 'type' property.")
+                  }
+
+                  if (this._listeners[event.type] instanceof Array) {
+                      var listeners = this._listeners[event.type]
+                      for (var i = 0, len = listeners.length; i < len; i++) {
+                          listeners[i].call(this, event)
+                      }
+                  }
+              },
+
+              removeEventListener: function (type, listener) {
+                  if (this._listeners[type] instanceof Array) {
+                      var listeners = this._listeners[type]
+                      for (var i = 0, len = listeners.length; i < len; i++) {
+                          if (listeners[i] === listener) {
+                              listeners.splice(i, 1)
+                              break
+                          }
+                      }
+                  }
+              },
+
+              open: function (method, url, async) {
+                  this.method = method
+                  this.url = url
+                  this.async = async
+              },
+              setRequestHeader: function (name, value) {
+                  this.headers.push({ name: name, value: value })
+              },
+              getResponseHeader: function (name) {
+                  return this.responseHeaders[name]
+              },
+              overrideMimeType: function (type) {
+                  this.responseHeaders['content-type'] = type
+              },
+              send: function (data) {
+                  this.data = data
+                  this.dispatchEvent($.event('loadstart'))
+                  if (this.timeout != 0){
+                      setTimeout(function(){
+                          this.aborted = true
+                          this.dispatchEvent($.event('timeout'))
+                      }, this.timeout)
+                  }
+              },
+              abort: function () {
+                  this.aborted = true
+              },
+              ready: function (readyState, status, responseText, headers) {
+                  this.readyState = readyState
+                  this.status = status
+                  this.statusText = '200 OK'
+                  this.responseText = this.response = responseText
+                  $.extend(this.responseHeaders, headers)
+                  if ( !((this.status >= 200 && this.status < 300) || this.status == 304)){
+                      this.dispatchEvent($.event('error'))
+                  }else{
+                      this.dispatchEvent($.event('load'))
+                  }
+                  this.onreadystatechange()
+                  this.dispatchEvent($.event('loadend'))
+              },
+              onreadystatechange: function () { }
+          }
+
+          function matchHeader(name, value) {
+              return function (header) {
+                  return header.name == name && (!value || header.value == value)
+              }
+          }
+
+          Evidence('ZeptoAjaxTest2', {
+              setUp: function () {
+                  $.ajaxSettings.xhr = function () { return new MockXHR }
+              },
+
+              tearDown: function () {
+                  $.ajaxSettings.xhr = OriginalXHR
+                  $(document).off()
+                  $.active = 0
+              },
+
+              testTypeDefaultsToGET: function (t) {
+                  $.ajax({
+                      url: '/foo',
+                      beforeSend: function (xhr, settings) {
+                      }
+                  })
+                  t.assertEqual('GET', MockXHR.last.method)
+              },
+
+              testURLDefaultsToWindowLocation: function (t) {
+                  $.ajax()
+                  t.assertEqual(window.location, MockXHR.last.url)
+              },
+
+              testHeadersOptionCanSetContentType: function (t) {
+                  $.ajax({ type: 'POST', data: [], headers: { 'Content-Type': 'application/hal+json'} })
+                  t.assert(MockXHR.last.headers.some(matchHeader('Content-Type', 'application/hal+json')))
+              },
+
+              testCustomHeader: function (t) {
+                  $.ajax({ headers: { 'X-Awesome': 'true'} })
+                  t.assert(MockXHR.last.headers.some(matchHeader('X-Requested-With', 'XMLHttpRequest')))
+                  t.assert(MockXHR.last.headers.some(matchHeader('X-Awesome', 'true')))
+              },
+
+              testJSONdataType: function (t) {
+                  var result = {}
+                  $.ajax({ responseType: 'json', done: function (json) { result = json } })
+                  MockXHR.last.ready(4, 200, '{"hello":"world"}')
+                  t.assertEqual("world", result.hello)
+              },
+
+              testJSONResponseBodiesAreNotParsedWhenDataTypeOptionIsJSONButResponseIsEmptyString: function (t) {
+                  var result, done = false
+                  $.ajax({ responseType: 'json', done: function (json) { result = json; done = true } })
+                  MockXHR.last.ready(4, 200, '')
+                  t.assert(done)
+                  t.assertNull(result)
+              },
+
+              testJSONResponseBodiesAreNotParsedWhenDataTypeOptionIsJSONButResponseIsSingleSpace: function (t) {
+                  var result, done = false
+                  $.ajax({ responseType: 'json', done: function (json) { result = json; done = true } })
+                  MockXHR.last.ready(4, 200, ' ')
+                  t.assert(done)
+                  t.assertNull(result)
+              },
+
+              testDataOptionIsConvertedToSerializedForm: function (t) {
+                  $.ajax({ data: { hello: 'world', array: [1, 2, 3], object: { prop1: 'val', prop2: 2}} })
+                  MockXHR.last.data = decodeURIComponent(MockXHR.last.data)
+                  t.assertEqual('hello=world&array[]=1&array[]=2&array[]=3&object[prop1]=val&object[prop2]=2', MockXHR.last.data)
+              },
+
+              testDataOptionIsConvertedToSerializedTraditionalForm: function (t) {
+                  $.ajax({ data: { hello: 'world', array: [1, 2, 3], object: { prop1: 'val', prop2: 2} }, traditional: true })
+                  MockXHR.last.data = decodeURIComponent(MockXHR.last.data)
+                  t.assertEqual('hello=world&array=1&array=2&array=3&object=[object+Object]', MockXHR.last.data)
+              },
+
+              testProcessDataDisabled: function (t) {
+                  var data = { country: 'Ecuador' }
+                  $.ajax({
+                      data: data,
+                      processData: false,
+                      type: "POST"
+                  })
+                  t.assertIdentical(data, MockXHR.last.data)
+              },
+
+              testDataIsAppendedToGETURL: function (t) {
+                  $.ajax({ url: 'test.html', data: 'foo=bar' })
+                  t.assertEqual('test.html?foo=bar', MockXHR.last.url)
+
+                  $.ajax({ url: 'test.html', data: '?foo=bar' })
+                  t.assertEqual('test.html?foo=bar', MockXHR.last.url)
+
+                  $.ajax({ url: 'test.html?', data: 'foo=bar' })
+                  t.assertEqual('test.html?foo=bar', MockXHR.last.url)
+
+                  $.ajax({ url: 'test.html?baz', data: 'foo=bar' })
+                  t.assertEqual('test.html?baz&foo=bar', MockXHR.last.url)
+
+                  $.ajax({ url: 'test.html?bar=baz', data: 'foo=bar' })
+                  t.assertEqual('test.html?bar=baz&foo=bar', MockXHR.last.url)
+
+                  $.ajax({ url: 'test.html', data: { foo: 'bar'} })
+                  t.assertEqual('test.html?foo=bar', MockXHR.last.url)
+              },
+
+              testErrorCallback: function (t) {
+                  var doneFired = false, xhr, status
+                  $.ajax({
+                      done: function () { doneFired = true },
+                      fail: function (s, x) { xhr = x, status = s }
+                  })
+
+                  MockXHR.last.ready(4, 500, '500 Internal Server Error')
+                  t.assert(!doneFired)
+                  t.assertEqual(MockXHR.last, xhr)
+                  t.assertEqual('error', status)
+              },
+
+              test201ResponseIsSuccess: function (t) {
+                  var doneFired, failFired
+                  $.ajax({
+                      done: function () { doneFired = true },
+                      fail: function () { failFired = true }
+                  })
+
+                  MockXHR.last.ready(4, 201, 'Created')
+                  t.assert(doneFired)
+                  t.refute(failFired)
+              },
+
+              test304ResponseIsSuccess: function (t) {
+                  var doneFired, failFired
+                  $.ajax({
+                      done: function () { doneFired = true },
+                      fail: function () { failFired = true }
+                  })
+
+                  MockXHR.last.ready(4, 304, 'Not Modified')
+                  t.assert(doneFired)
+                  t.refute(failFired)
+              },
+              testXHRParameterInSuccessCallback: function (t) {
+                  var body, status, xhr
+                  $.ajax({
+                      done: function (b, s, x) { body = b, status = s, xhr = x }
+                  })
+
+                  MockXHR.last.ready(4, 200, 'Hello')
+                  t.assertEqual('Hello', body)
+                  t.assertEqual('200 OK', status)
+                  t.assertEqual(MockXHR.last, xhr)
+
+                  body = status = xhr = null
+                  $.ajax({
+                      responseType: 'json',
+                      done: function (b, s, x) { body = b, status = s, xhr = x }
+                  })
+
+                  MockXHR.last.ready(4, 200, '{"message":"Hello"}')
+                  t.assertEqual('Hello', body.message)
+                  t.assertEqual('200 OK', status)
+                  t.assertEqual(MockXHR.last, xhr)
+              },
+
+              testBeforeSendAbortCallback: function (t) {
+                  var xhr, beforeFired = false, settings = {}
+                  $.ajax({
+                      data: "1=2",
+                      beforeSend: function (x, s) {
+                          beforeFired = true, settings = s, xhr = x
+                      }
+                  })
+
+                  t.assert(beforeFired)
+                  t.assertEqual(MockXHR.last, xhr)
+                  t.assertEqual("1=2", settings.data)
+              },
+
+              testBeforeSendAbort: function (t) {
+                  var xhr
+                  $.ajax({ beforeSend: function (x) { xhr = x; return false } })
+
+                  t.assert(xhr.aborted)
+              },
+
+              testGlobalBeforeSendAbort: function (t) {
+                  var xhr
+                  $(document).on('ajaxBeforeSend', function (x, s) { xhr = x; return false })
+                  t.assertFalse($.ajax())
+                  t.assert(xhr.aborted)
+              },
+
+              testGlobalAjaxStartCantAbort: function (t) {
+                  var xhr
+                  $(document).on('ajaxStart', function (x, s) { xhr = x; return false })
+                  t.assert($.ajax())
+                  t.assert(!xhr.aborted)
+              },
+
+              testCompleteCallback: function (t) {
+                  var settings, xhr
+                  $.ajax({ always: function (x, s) { settings = s, xhr = x } })
+
+                  MockXHR.last.ready(4, 200, 'OK')
+                  t.assertEqual(MockXHR.last, xhr)
+                  //t.assertEqual('success', status) Always does not return a status
+              },
+
+              testCallbackOrder: function (t) {
+                  var order = []
+                  $.ajax({
+                      beforeSend: function () { order.push('beforeSend') },
+                      done: function () { order.push('done') },
+                      always: function () { order.push('always') }
+                  })
+
+                  MockXHR.last.ready(4, 200, 'OK')
+                  t.assertEqual('beforeSend,done,always', order.join(','))
+              },
+
+              testGlobalCallbacks: function (t) {
+                  var fired = []
+                  $(document).on('ajaxBeforeSend ajaxStart ajaxSuccess ajaxError ajaxStop', function (e) {
+                      fired.push(e.type)
+                  })
+
+                  $.ajax({
+                      beforeSend: function () { fired.push('beforeSend') },
+                      done: function () { fired.push('done') },
+                      fail: function () { fired.push('fail') },
+                      always: function () { fired.push('always') }
+                  })
+                  t.assertEqual('beforeSend ajaxBeforeSend ajaxStart ajaxStart', fired.join(' '))
+
+                  fired = []
+                  MockXHR.last.ready(4, 200, 'OK')
+                  t.assertEqual('done ajaxSuccess always ajaxStop', fired.join(' '))
+              },
+
+              testGlobalCallbacksOff: function (t) {
+                  var fired = []
+                  $(document).on('ajaxBeforeSend ajaxStart ajaxSuccess ajaxError ajaxStop', function (e) {
+                      fired.push(e.type)
+                  })
+
+                  $.ajax({
+                      global: false,
+                      beforeSend: function () { fired.push('beforeSend') },
+                      done: function () { fired.push('done') },
+                      fail: function () { fired.push('fail') },
+                      always: function () { fired.push('always') }
+                  })
+                  t.assertEqual('beforeSend', fired.join(' '))
+
+                  fired = []
+                  MockXHR.last.ready(4, 200, 'OK')
+                  t.assertEqual('done always', fired.join(' '))
+              },
+
+              testTimeout: function (t) {
+                  var doneFired = false, xhr, status
+                  t.pause()
+                  $.ajax({
+                      timeout: 30,
+                      done: function () { doneFired = true },
+                      fail: function (x, s) { xhr = x, status = s }
+                  })
+
+                  setTimeout(function () {
+                      t.assertFalse(doneFired)
+                      t.assertUndefined(status)
+                  }, 20)
+
+                  setTimeout(function () {
+                      t.resume(function () {
+                          t.assertFalse(doneFired)
+                          t.assertTrue(xhr.aborted)
+                          t.assertEqual('timeout', status)
+                      })
+                  }, 40)
+              }
+          })
+
+          Evidence('ZeptoAjaxHelperMethodsTest', {
+
+              testParamMethod: function (t) {
+                  var result = $.param({ libs: ['jQuery', 'script.aculo.us', 'Prototype', 'Dojo'] })
+                  result = decodeURIComponent(result)
+                  t.assertEqual(result, "libs[]=jQuery&libs[]=script.aculo.us&libs[]=Prototype&libs[]=Dojo")
+
+                  result = $.param({ jquery: 'Javascript', rails: 'Ruby', django: 'Python' })
+                  result = decodeURIComponent(result)
+                  t.assertEqual(result, "jquery=Javascript&rails=Ruby&django=Python")
+
+                  result = $.param({
+                      title: "Some Countries",
+                      list: ['Ecuador', 'Austria', 'England'],
+                      capitals: { ecuador: 'Quito', austria: 'Vienna', GB: { england: 'London', scotland: 'Edinburgh'} }
+                  })
+                  result = decodeURIComponent(result)
+                  t.assertEqual(result, "title=Some+Countries&list[]=Ecuador&list[]=Austria&list[]=England&capitals[ecuador]=Quito&capitals[austria]=Vienna&capitals[GB][england]=London&capitals[GB][scotland]=Edinburgh")
+              },
+
+              testParamEscaping: function (t) {
+                  var result = $.param({ 'equation[1]': 'bananas+peaches=smoothie' })
+                  t.assertEqual("equation%5B1%5D=bananas%2Bpeaches%3Dsmoothie", result)
+              },
+
+              testParamSpaces: function (t) {
+                  var result = $.param({ "foo bar": "baz kuux" })
+                  t.assertEqual("foo+bar=baz+kuux", result)
+              },
+
+              testParamComplex: function (t) {
+                  var data = {
+                      a: ['b', 'c', { d: 'e', f: ['g', 'h']}]
+                  }
+                  var result = $.param(data)
+                  result = decodeURIComponent(result)
+                  t.assertEqual("a[]=b&a[]=c&a[][d]=e&a[][f][]=g&a[][f][]=h", result)
+              },
+
+              testParamShallow: function (t) {
+                  var data = {
+                      libs: ['jQuery', 'Prototype', 'Dojo'],
+                      nested: { will: 'be ignored' }
+                  }
+                  var result = $.param(data, true)
+                  result = decodeURIComponent(result)
+                  t.assertEqual("libs=jQuery&libs=Prototype&libs=Dojo&nested=[object+Object]", result)
+              },
+
+              testParamArray: function (t) {
+                  var data = [
+                { name: 'country', value: 'Ecuador' },
+                { name: 'capital', value: 'Quito' }
+              ]
+                  var result = $.param(data)
+                  t.assertEqual(result, "country=Ecuador&capital=Quito")
+              }
+
+          })
+      })()
+  </script>
+</body>
+</html>

--- a/test/ajax2.html
+++ b/test/ajax2.html
@@ -104,9 +104,9 @@
                   return this.handler(name, function () {
                       var context = this, args = arguments
                       //setTimeout(function () {
-                          that.testCase.resume(function () {
-                              if (fn) fn.apply(context, args)
-                          })
+                      that.testCase.resume(function () {
+                          if (fn) fn.apply(context, args)
+                      })
                       //}, 5)
                   })
               },
@@ -468,8 +468,10 @@
 
                   if (this._listeners[event.type] instanceof Array) {
                       var listeners = this._listeners[event.type]
+                      var data = [event]
+                      data.concat(event.data)
                       for (var i = 0, len = listeners.length; i < len; i++) {
-                          listeners[i].call(this, event)
+                          listeners[i].apply(this, data)
                       }
                   }
               },
@@ -502,11 +504,11 @@
               },
               send: function (data) {
                   this.data = data
-                  this.dispatchEvent($.event('loadstart'))
+                  this.dispatchEvent($.Event('loadstart'))
                   if (this.timeout != 0) {
                       setTimeout(function () {
                           this.aborted = true
-                          this.dispatchEvent($.event('timeout'))
+                          this.dispatchEvent($.Event('timeout'))
                       }, this.timeout)
                   }
               },
@@ -520,12 +522,12 @@
                   this.responseText = this.response = responseText
                   $.extend(this.responseHeaders, headers)
                   if (!((this.status >= 200 && this.status < 300) || this.status == 304)) {
-                      this.dispatchEvent($.event('error'))
+                      this.dispatchEvent($.Event('error'))
                   } else {
-                      this.dispatchEvent($.event('load'))
+                      this.dispatchEvent($.Event('load'))
                   }
                   this.onreadystatechange()
-                  this.dispatchEvent($.event('loadend'))
+                  this.dispatchEvent($.Event('loadend'))
               },
               onreadystatechange: function () { }
           }
@@ -764,7 +766,7 @@
                       fail: function () { fired.push('fail') },
                       always: function () { fired.push('always') }
                   })
-                  t.assertEqual('beforeSend ajaxBeforeSend ajaxStart ajaxStart', fired.join(' '))
+                  t.assertEqual('beforeSend ajaxBeforeSend ajaxStart', fired.join(' '))
 
                   fired = []
                   MockXHR.last.ready(4, 200, 'OK')
@@ -797,7 +799,7 @@
                   $.ajax({
                       timeout: 30,
                       done: function () { doneFired = true },
-                      fail: function (x, s) { xhr = x, status = s }
+                      fail: function (e, x, s) { xhr = x, status = s }
                   })
 
                   setTimeout(function () {

--- a/test/runner.coffee
+++ b/test/runner.coffee
@@ -27,7 +27,7 @@ page.onError = (msg, trace) ->
   console.log 'ERROR: ' + msg
 
 # used for waiting until the tests finish running
-waitFor = (testFn, onReady, timeout=3000) ->
+waitFor = (testFn, onReady, timeout=10000) ->
   start = new Date()
   interval = setInterval ->
     if testFn()

--- a/test/runner.coffee
+++ b/test/runner.coffee
@@ -15,7 +15,7 @@ if args.length > 0
   suites = args
 else
   # by default, run all test/*.html pages
-  modules = 'zepto ajax data detect event form fx selector stack'.split /\s+/
+  modules = 'zepto ajax ajax2 data detect event form fx selector stack'.split /\s+/
   suites = modules.map (name)-> "test/#{name}.html"
 
 page = require('webpage').create()


### PR DESCRIPTION
Ajax2 uses XMLHttpRequest2 which supports FIFO events. Instead of
returning the XHR object directly, it returns a zepto wrapped object
with custom methods to add context-aware callbacks.

Allows use of post-execution callbacks similar to those of the jQuery AJAX object:
http://api.jquery.com/jQuery.ajax/#entry-examples

Documentation will come if merged into the main Zepto.JS

NOTE: jsonp has been deprecated and removed. AJAX2 is now focused around CORS for cross domain calls.