### PR TITLE
Ensure animate callback always triggered

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -76,15 +76,24 @@
       }
     }
 
+    var fired = false
     wrappedCallback = function(event){
       if (typeof event !== 'undefined') {
         if (event.target !== event.currentTarget) return // makes sure the event didn't bubble from "below"
         $(event.target).unbind(endEvent, wrappedCallback)
       }
+      fired = true
       $(this).css(cssReset)
       callback && callback.call(this)
     }
-    if (duration > 0) this.bind(endEvent, wrappedCallback)
+    if (duration > 0){
+      this.bind(endEvent, wrappedCallback)
+      //transitionEnd not always fired on some android phones
+      setTimeout(function(){
+        if(fired) return
+        that.each(function(){ wrappedCallback.call(this) })
+      }, duration)
+    }
 
     // trigger page reflow so new elements can animate
     this.size() && this.get(0).clientLeft


### PR DESCRIPTION
Run this code on my Galaxy S3 (Android 4.1)

``` javascript
scroller.animate({
    translateX : '-500px'
}, 300, 'ease-out', function(){
    alert('hello, callback here');
});
```

The callback never runs. 
Tested on ios, and it works.
