### PR TITLE
Ensure animate callback always triggered

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -81,6 +81,9 @@
       if (typeof event !== 'undefined') {
         if (event.target !== event.currentTarget) return // makes sure the event didn't bubble from "below"
         $(event.target).unbind(endEvent, wrappedCallback)
+      }else{
+        //triggered by setTimeout
+        $(this).unbind(endEvent, wrappedCallback)
       }
       fired = true
       $(this).css(cssReset)
@@ -91,7 +94,7 @@
       //transitionEnd not always fired on some android phones
       setTimeout(function(){
         if(fired) return
-        that.each(function(){ wrappedCallback.call(this) })
+        wrappedCallback.call(that)
       }, duration * 1000)
     }
 


### PR DESCRIPTION
Run this code on my Galaxy S3 (Android 4.1)

``` javascript
scroller.animate({
    translateX : '-500px'
}, 300, 'ease-out', function(){
    alert('hello, callback here');
});
```

The callback never runs. 
Tested on ios, and it works.
