### PR TITLE
$.param fix for sparse array

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -295,9 +295,10 @@
     var type, array = $.isArray(obj)
     $.each(obj, function(key, value) {
       type = $.type(value)
+      if(type == "undefined") return
       if (scope) key = traditional ? scope : scope + '[' + (array ? '' : key) + ']'
       // handle data in serializeArray() format
-      if (!scope && array) params.add(value.name, value.value)
+      if (!scope && array && type == "object") params.add(value.name, value.value)
       // recurse into nested objects
       else if (type == "array" || (!traditional && type == "object"))
         serialize(params, value, traditional, key)

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -1051,6 +1051,14 @@
         ]
         var result = $.param(data)
         t.assertEqual(result, "country=Ecuador&capital=Quito")
+      },
+
+      testParamSparseArray: function(t){
+        var data = []
+        data[5] = "NotEmpty"
+        data[10] = "NotEmpty"
+        var result = $.param(data)
+        t.assertEqual(result,"5=NotEmpty&10=NotEmpty")
       }
 
     })


### PR DESCRIPTION
$.param run to an error with a array like this:

``` javascript
var arr = [], arr[5] = 1, arr[10] = 2, arr[15] = 3
var result = $.param(arr)
```

**Error: name is undefined**
Here is a simple fix.
