### PR TITLE
fix to $.trim

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -288,8 +288,7 @@ var Zepto = (function() {
 
   $.camelCase = camelize
   $.trim = function(str) {
-    if($.type(str) == "string") return str.trim()
-    else return undefined;
+    return str == null ? "" : String.prototype.trim.call(str)
   }
 
   // plugin compatibility

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -364,7 +364,8 @@
       // test to see if we augment iOS 3.2 with String#trim()
       testTrim: function(t){
         t.assertEqual("blah", " blah ".trim())
-        t.assertEqual(undefined, $.trim(undefined))
+        t.assertEqual("", $.trim(undefined))
+        t.assertEqual("", $.trim(null))
         t.assertEqual("", $.trim(""))
       },
 


### PR DESCRIPTION
This is just a protection for trimming undefined value 

``` javascript
var foo = {}
$.trim(foo.bar)  --> throw an error.
```
