### PR TITLE
fixing ajax post with serialized array data

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -295,7 +295,7 @@
     var type, array = $.isArray(obj)
     $.each(obj, function(key, value) {
       type = $.type(value)
-      if (scope) key = traditional ? scope : scope + '[' + (array ? '' : key) + ']'
+      if (scope) key = traditional ? scope : scope + '[' + key + ']'
       // handle data in serializeArray() format
       if (!scope && array) params.add(value.name, value.value)
       // recurse into nested objects


### PR DESCRIPTION
post data as a JS object:
{
  foo : [
    bar : 'baz'
  ]
}

gets serialized as:
foo%5B%5Dbar%5Bbar%5D=baz
of
foo[][bar]=baz

with out the explicit index, node connect chokes and reconstructs the data as:
foo = [ bar, baz ]
