### PR TITLE
Fix wrapAll example in docs

### DIFF
--- a/core/_posts/1900-01-01-wrapAll.md
+++ b/core/_posts/1900-01-01-wrapAll.md
@@ -9,5 +9,5 @@ several nested elements, and can be passed in as a HTML string or DOM node.
 
 {% highlight js %}
 // wrap all buttons in a single div:
-$('a.button').wrap('<div id=buttons />')
+$('a.button').wrapAll('<div id=buttons />')
 {% endhighlight %}


### PR DESCRIPTION
It said `wrap` instead of `wrapAll`. This fixes it.
