### PR TITLE
Allow Zepto to work with jQuery in noConflict mode

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -789,4 +789,4 @@ var Zepto = (function() {
 
 // If `$` is not yet defined, point it to `Zepto`
 window.Zepto = Zepto
-if (window.$ == undefined) window.$ = Zepto
+window.$ === undefined && (window.$ = Zepto)


### PR DESCRIPTION
- Check that window.$ is undefined rather than whether $ is a property
  of window.
- jQuery in noConflict mode sets window.$ to undefined which was causing
  Zepto to not be assigned
