### PR TITLE
Use `classList` to manipulate classes in modern browsers

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -634,7 +634,7 @@ var Zepto = (function() {
       return element ? this.indexOf($(element)[0]) : this.parent().children().indexOf(this[0])
     },
     hasClass: function(name){
-      return emptyArray.some.call(this, function(el){
+      return this.classList ? this.contains(name) : emptyArray.some.call(this, function(el){
         return this.test(className(el))
       }, classRE(name))
     },


### PR DESCRIPTION
使用高级浏览器提供的classList接口来操作class，在高级浏览器中普遍支持该接口。浏览器内部会优化class操作，减少recalculate和repainting造成的渲染消耗。
