### PR TITLE
Implemented missing set for scrollTop([val])

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -669,9 +669,9 @@ var Zepto = (function() {
     },
     scrollTop: function(val){
       if (!this.length) return
-      var p = ('scrollTop' in this[0]) ? 'scrollTop' : 'scrollY'
-      if (val === undefined) return this[0][p]
-      return this.each(function(){ this[p] = val })
+      var e = 'scrollTop' in this[0]
+      if (val === undefined) return e ? this[0].scrollTop : this[0].scrollY
+      return this.each(e ? function(){this.scrollTop = val} : function(){this.scrollTo(this.scrollX, val)})
     },
     position: function() {
       if (!this.length) return

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -2233,8 +2233,11 @@
       },
 
       testScrollTop: function(t) {
-        t.assert($(window).scrollTop() >= 0)
-        t.assert($(document.body).scrollTop() >= 0)
+        var w = $(window), b = $(document.body)
+        t.assert(w.scrollTop() >= 0)
+        t.assert(b.scrollTop() >= 0)
+        t.assertIdentical(w.scrollTop(20), w)
+        t.assertIdentical(b.scrollTop(20), b)
       },
 
       testSort: function(t){


### PR DESCRIPTION
Setting scrollTop is a much used technique for figuring out content height, which in turn is usually how auto-resize is implemented. This change makes most jquery.autoresize plugins work as-is.
