### PR TITLE
When using show() it should use the original opacity value and default it to 1.

### DIFF
--- a/src/fx_methods.js
+++ b/src/fx_methods.js
@@ -27,7 +27,7 @@
     origShow.call(this)
     if (speed === undefined) speed = 0
     else this.css('opacity', 0)
-    return anim(this, speed, 1, '1,1', callback)
+    return anim(this, speed, this.css('opacity') || 1, '1,1', callback)
   }
 
   $.fn.hide = function(speed, callback) {


### PR DESCRIPTION
I was having a problem when using `show()` where Zepto always forced the opacity of the element that I'm animating to 1. But there are cases when I already have an opacity value pre defined and want to keep that. I can do that with jQuery but with Zepto I would have to do something like `$('.class').show().css('opacity', .5);`
This is a really small implementation but I think it's a good addition to the `fx` module.
