### PR TITLE
Added description about 'return false'

### DIFF
--- a/event/_posts/1900-01-01-on.md
+++ b/event/_posts/1900-01-01-on.md
@@ -12,7 +12,7 @@ only be called when an event originates from an element that matches the selecto
 
 Event handlers are executed in the context of the element to which the handler
 is attached, or the matching element in case a selector is provided. When an
-event handler returns `false`, `preventDefault()` is called for the current
+event handler returns `false`, `preventDefault()` and `stopPropagation()` is called for the current
 event, preventing the default browser action such as following links.
 
 {% highlight js %}


### PR DESCRIPTION
Document that returning `false` from an event handler stops propagation of the event (in addition to preventing default events).
