### PR TITLE
Fixes #647: Update android regex to match Firefox for Android.

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -6,7 +6,7 @@
   function detect(ua){
     var os = this.os = {}, browser = this.browser = {},
       webkit = ua.match(/WebKit\/([\d.]+)/),
-      android = ua.match(/(Android)\s+([\d.]+)/),
+      android = ua.match(/(Android);?\s+([\d.]+)?/),
       ipad = ua.match(/(iPad).*OS\s([\d_]+)/),
       ipod = ua.match(/(iPod)(.*OS\s([\d_]+))?/),
       iphone = !ipad && ua.match(/(iPhone\sOS)\s([\d_]+)/),

--- a/test/detect.html
+++ b/test/detect.html
@@ -337,6 +337,7 @@
         detect(UA.Firefox_13_Tablet, function(os, browser){
           t.assertTrue(browser.firefox)
           t.assertFalse(browser.webkit)
+          t.assertTrue(os.android)
           t.assertFalse(os.phone)
           t.assertTrue(os.tablet)
         })
@@ -344,6 +345,7 @@
         detect(UA.Firefox_13_Phone, function(os, browser){
           t.assertTrue(browser.firefox)
           t.assertFalse(browser.webkit)
+          t.assertTrue(os.android)
           t.assertTrue(os.phone)
           t.assertFalse(os.tablet)
         })


### PR DESCRIPTION
Firefox for Android doesn't include Android version information
in the UA string. This change allows the regex to detect Firefox
for Android as an Android browser with the caveat that os.version
will be undefined. But this can still be useful when trying to
distinguish between ios and android, for example.

Not sure if it makes sense to add a note in the documentation, it seems like that's kind of covered by:

```
// The following boolean flags are set to true if they apply,
// if not they're either set to `false` or `undefined`.
```

But I'm happy to send a docs PR if you guys think that would be helpful. Thanks!
