### PR TITLE
Data for elements that don't contain attributes.

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -6,7 +6,7 @@
 
 ;(function($) {
   var data = {}, dataAttr = $.fn.data, camelize = $.camelCase,
-    exp = $.expando = 'Zepto' + (+new Date())
+    exp = $.expando = 'Zepto' + (+new Date()), emptyArray = []
 
   // Get value from node:
   // 1. first try key as given,
@@ -36,7 +36,7 @@
   // Read all "data-*" attributes from a node
   function attributeData(node) {
     var store = {}
-    $.each(node.attributes, function(i, attr){
+    $.each(node.attributes || emptyArray, function(i, attr){
       if (attr.name.indexOf('data-') == 0)
         store[camelize(attr.name.replace('data-', ''))] =
           $.zepto.deserializeValue(attr.value)

--- a/test/data.html
+++ b/test/data.html
@@ -209,6 +209,14 @@
 
           var values2 = items.map(function(){ return $(this).data('answer') }).get()
           t.assertEqual('42, 42', values2.join(', '))
+      },
+
+      testSettingDataOnObjectWithoutAttributes: function(t) {
+        var el = $(window)
+
+        t.assertUndefined(el.data('foo'))
+        el.data('foo', 'bar')
+        t.assertEqual(el.data('foo'), 'bar')
       }
 
     })


### PR DESCRIPTION
Note: This requests is specific to the data.js module.

Attempting to set data on DOM elements that don't contain attributes (e.g. $(window)) results in a TypeError (Cannot read property 'length' of undefined). Essentially this happens because the code assumes all elements contain attributes.

The pull request contains minor changes to `attributeData` which uses attributes if they exist or fall-backs to an empty array otherwise. I've added a test and executed it on;
### Desktop
- Chrome (30.0.1599.101)
- FF (24.0).
### Mobile
- Android (Chrome) 4.2.2
- iOS 5 (Safari)

I hope this makes sense ... if not then let me know.
