### PR TITLE
When calling .removeData() with no arguments, remove all data values on the element

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -61,7 +61,9 @@
     if (typeof names == 'string') names = names.split(/\s+/)
     return this.each(function(){
       var id = this[exp], store = id && data[id]
-      if (store) $.each(names, function(){ delete store[camelize(this)] })
+      if (store) $.each(names || store, function(key){
+        delete store[names ? camelize(this) : key]
+      })
     })
   }
 })(Zepto)

--- a/test/data.html
+++ b/test/data.html
@@ -166,6 +166,19 @@
         t.assertUndefined(el.data('twoThree'))
       },
 
+      testRemoveAllData: function(t){
+        var el = $('<div data-attr-test=val />')
+
+        el.data('one', { foo: 'bar' })
+        el.data('two', 'two').data('three', 3)
+        el.removeData()
+
+        t.assertEqual('val', el.data('attrTest'))
+        t.assertUndefined(el.data('one'))
+        t.assertUndefined(el.data('two'))
+        t.assertUndefined(el.data('three'))
+      },
+
       testRemoveDataNoop: function(t){
         var empty = $(),
             vanilla = $('<div />')


### PR DESCRIPTION
Allows calling .removeData() with no arguments to remove all values that were previously set using .data() on the element. Corresponds to jQuery behaviour.

Previously, an error was triggered when trying to do this with Zepto.
