### PR TITLE
fix fx_methods.js

### DIFF
--- a/src/fx_methods.js
+++ b/src/fx_methods.js
@@ -24,10 +24,12 @@
   }
 
   $.fn.show = function(speed, callback) {
-    origShow.call(this)
-    if (speed === undefined) speed = 0
-    else this.css('opacity', 0)
-    return anim(this, speed, 1, '1,1', callback)
+    if(speed === undefined) 
+      return origShow.call(this)
+    else {
+      this.css('opacity', 0)
+      return anim(this, speed, 1, '1,1', callback)
+    }
   }
 
   $.fn.hide = function(speed, callback) {


### PR DESCRIPTION
The function "$.fn.show " has a bug.
When I do not pass arguments like "$('div').show()",it will jump into anim function, then set some css codes that i do not need.
