### PR TITLE
Fix discrepancy with the way jQuery does $.param(). Issue 850

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -297,10 +297,14 @@
   var escape = encodeURIComponent
 
   function serialize(params, obj, traditional, scope){
-    var type, array = $.isArray(obj)
+    var type, array = $.isArray(obj), arrayIndex = 0;
     $.each(obj, function(key, value) {
       type = $.type(value)
-      if (scope) key = traditional ? scope : scope + '[' + (array ? '' : key) + ']'
+      if (scope) {
+      	if (traditional) key = scope
+      	else key = scope + '[' + (array ? type == 'object' ? arrayIndex : '' : key) + ']' // if current is an object, use a key, if current is array and value is an object use a numeric index, if current is array and value is non-object use no index...
+      } 
+      arrayIndex++
       // handle data in serializeArray() format
       if (!scope && array) params.add(value.name, value.value)
       // recurse into nested objects

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -1144,7 +1144,16 @@
         }
         var result = $.param(data)
         result = decodeURIComponent(result)
-        t.assertEqual("a[]=b&a[]=c&a[][d]=e&a[][f][]=g&a[][f][]=h", result)
+        t.assertEqual("a[]=b&a[]=c&a[2][d]=e&a[2][f][]=g&a[2][f][]=h", result)
+      },
+
+      testParamComplexIssue850: function(t) {
+        var data = {
+          $push: { _:[ { name: 'bob', members:['aaa'] } ] }
+        }
+        var result = $.param(data)
+        result = decodeURIComponent(result)
+        t.assertEqual("$push[_][0][name]=bob&$push[_][0][members][]=aaa", result)
       },
 
       testParamShallow: function(t) {


### PR DESCRIPTION
Old behaviour for $.param() misses out indexes for arrays which have objects within them whereas jQuery (1.4 and 1.latest tested) will add them in this situation.

I have:
1. Updated code so it creates data which is the same as what jQuery would produce.
2. Updated AJAX test "testParamComplex" so it tests for data that jQuery would actually produce (the test was wrong).
3. Added a new test which for the un-jQuery-like / incompatible node-querystring (Express) which was discovered in issue 850.

AJAX Tests still passing (in browsers)
