### PR TITLE
Increased the default test timeout.

### DIFF
--- a/test/runner.coffee
+++ b/test/runner.coffee
@@ -27,7 +27,7 @@ page.onError = (msg, trace) ->
   console.log 'ERROR: ' + msg
 
 # used for waiting until the tests finish running
-waitFor = (testFn, onReady, timeout=3000) ->
+waitFor = (testFn, onReady, timeout=4000) ->
   start = new Date()
   interval = setInterval ->
     if testFn()


### PR DESCRIPTION
Locally the `zepto.html` tests take just over 3 seconds to run and since this is higher than the default test/runner timeout, it console.logs `timed out` and then phantomjs exits before completing the test run.

Travis-ci appears to be doing the same thing, so I suspect travis-ci should start running all of the tests again with this change.
