### PR TITLE
Added "main" field to "package.json" for publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "zepto"
   , "version": "1.0.0"
   , "homepage": "http://zeptojs.com"
+  , "main": "dist/zepto.js"
   , "scripts": {
       "test": "coffee make test"
     , "dist": "coffee make dist"


### PR DESCRIPTION
Would be great if Zepto was published to npm again for use with browserify and ender.
