### PR TITLE
Set xhr attributes after xhr.open() method is called

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -256,10 +256,10 @@
       return xhr
     }
 
-    if (settings.xhrFields) for (name in settings.xhrFields) xhr[name] = settings.xhrFields[name]
-
     var async = 'async' in settings ? settings.async : true
     xhr.open(settings.type, settings.url, async, settings.username, settings.password)
+
+    if (settings.xhrFields) for (name in settings.xhrFields) xhr[name] = settings.xhrFields[name]
 
     for (name in headers) nativeSetHeader.apply(xhr, headers[name])
 


### PR DESCRIPTION
This avoids bug in IE and Android stock browser where setting
xhr.withCredentials before calling xhr.open() throws InvalidStateError.
