### PR TITLE
cleared up confusion about the global coffee variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,12 @@ The resulting files are:
 1. `dist/zepto.js`
 2. `dist/zepto.min.js`
 
-If you install CoffeeScript globally, you can run `make` directly:
+You can also create a custom build by defining the
+`MODULES` environment variable and then using `coffee` to run the
+makefile directly:
 
 ~~~ sh
-$ coffee make dist
-$ MODULES="zepto event data ..." ./make dist
+$ MODULES="zepto event data ..." ./node_modules/.bin/coffee make dist
 ~~~
 
 ## Zepto modules


### PR DESCRIPTION
I might just be an idiot, but it took me a good 10 minutes to figure out how to create a custom build. The fact that it required coffeescript threw me for a loop, so I made the custom build example a little more explicit (you don't actually need to install coffee globally).
