### PR TITLE
Provide cleanup stub for JSONP cleanups

### DIFF
--- a/test/evidence_runner.js
+++ b/test/evidence_runner.js
@@ -94,7 +94,7 @@
 
   function displayResults(results, seconds) {
     var container = $('results')
-    if (container) {
+    if (container && !container.className) {
       if (results.failureCount || results.errorCount) {
         container.className = 'failed'
         container.innerHTML = printf("Finished in %d s. &ndash; <em>%d failures, %d errors</em> (%d assertions)",
@@ -105,6 +105,14 @@
                                      [seconds, results.testCount, results.assertionCount])
       }
       container.className += ' finished'
+    }
+  }
+
+  window.onerror = function(msg) {
+    var container = $('results')
+    if (container) {
+      container.className = 'failed finished'
+      container.innerHTML = printf("global onerror: %s", [msg])
     }
   }
 

--- a/test/runner.coffee
+++ b/test/runner.coffee
@@ -23,7 +23,9 @@ page = require('webpage').create()
 page.onConsoleMessage = (msg) ->
   console.log msg
 
+globalError = false
 page.onError = (msg, trace) ->
+  globalError = msg
   console.log 'ERROR: ' + msg
 
 # used for waiting until the tests finish running
@@ -64,9 +66,10 @@ loadNextSuite = ->
           console.log "#{paths[paths.length - 1]} - " + res.textContent
           /passed/.test res.className
 
-        if passed
+        if passed and not globalError
           loadNextSuite()
         else
+          console.log "#{paths[paths.length - 1]} - global error #{globalError}" if globalError
           phantom.exit(1)
 
 loadNextSuite()

--- a/test/server.coffee
+++ b/test/server.coffee
@@ -84,7 +84,9 @@ app.get '/test/json', (req, res) ->
 
 app.all '/test/slow', (req, res) ->
   setTimeout ->
-    res.send 'DONE'
+    res.jsonp
+      query: req.query
+      hello: 'world'
   , 200
 
 app.get '/test/cached', (req, res) ->


### PR DESCRIPTION
Prevents global errors for environments that do not terminal script execution when dynamic scripts are removed from the DOM.

This appears to be the case under iOS and Windows phone among others. Note that this issue is not reproducible within PhantomJS as removed scripts have early termination in that environment.