### PR TITLE
Threshold on touchmove before cancelling longTap

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -90,12 +90,14 @@
         if((_isPointerType = isPointerEventType(e, 'move')) &&
           !isPrimaryTouch(e)) return
         firstTouch = _isPointerType ? e : e.touches[0]
-        cancelLongTap()
+
         touch.x2 = firstTouch.pageX
         touch.y2 = firstTouch.pageY
 
         deltaX += Math.abs(touch.x1 - touch.x2)
         deltaY += Math.abs(touch.y1 - touch.y2)
+
+        if ((Math.abs(deltaX) > 1) || (Math.abs(deltaY) > 1)) cancelLongTap()
       })
       .on('touchend MSPointerUp pointerup', function(e){
         if((_isPointerType = isPointerEventType(e, 'up')) &&


### PR DESCRIPTION
Ostensibly this is to fix an issue on Blackberry10. On that platform,
the `touchmove` event was always firing causing `cancelLongTap()` to
fire. I knew that HammerJS long press events worked in bb10 and they
were setting a threshold. After adding a similar threshold to the
`touchmove` event, Zepto `longTap` events began to work as well.

I have tested this against numerous devices and browsers, including
those on iOS, Android, Chrome, Firefox and Safari. All touch tests
passed in every environment.