### PR TITLE
Removing an element should also remove its event listeners

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -265,12 +265,16 @@
     }
   })
 
-  // remove() also removes event listeners
-  var fn_remove = $.fn.remove;
-  $.fn.remove = function() {
-    this.off();
-    return fn_remove.call(this);
-  }
+  // Generate extended `remove` and `empty` functions
+  ;['remove', 'empty'].forEach(function(methodName){
+    var origFn = $.fn[methodName]
+    $.fn[methodName] = function() {
+      var elements = this.find('*')
+      if (methodName === 'remove') elements = elements.add(this)
+      elements.off()
+      return origFn.call(this)
+    }
+  })
 
   $.Event = function(type, props) {
     if (!isString(type)) props = type, type = props.type

--- a/src/event.js
+++ b/src/event.js
@@ -271,7 +271,9 @@
     $.fn[methodName] = function() {
       var elements = this.find('*')
       if (methodName === 'remove') elements = elements.add(this)
-      elements.off()
+      elements.forEach(function(elem){
+        remove(elem)
+      })
       return origFn.call(this)
     }
   })

--- a/src/event.js
+++ b/src/event.js
@@ -265,6 +265,13 @@
     }
   })
 
+  // remove() also removes event listeners
+  var fn_remove = $.fn.remove;
+  $.fn.remove = function() {
+    this.off();
+    return fn_remove.call(this);
+  }
+
   $.Event = function(type, props) {
     if (!isString(type)) props = type, type = props.type
     var event = document.createEvent(specialEvents[type] || 'Events'), bubbles = true

--- a/test/event.html
+++ b/test/event.html
@@ -425,6 +425,17 @@
         span.trigger(event)
         t.assertTrue(event.isDefaultPrevented())
         t.assertTrue(event.isPropagationStopped())
+      },
+
+      testRemovingElementRemovesEvents: function(t) {
+        var span = $('<span>').appendTo(this.el);
+        var called = false;
+        span.on('event', function() {
+          called = true;
+        });
+        span.remove();
+        span.trigger('event');
+        t.assertFalse(called);
       }
 
     })

--- a/test/event.html
+++ b/test/event.html
@@ -436,6 +436,35 @@
         span.remove();
         span.trigger('event');
         t.assertFalse(called);
+      },
+
+      testEmptyingElementRemovesEvents: function(t) {
+        var el = $('<div />'),
+          childEl = $('<span />').appendTo(el),
+          childCalled = false,
+          parentCalled = false;
+        el.on('event', function() {
+          parentCalled = true;
+        })
+        childEl.on('event', function() {
+          childCalled = true;
+        });
+        el.empty();
+        childEl.trigger('event');
+        el.trigger('event');
+        t.assertFalse(childCalled);
+        t.assertTrue(parentCalled);
+      },
+
+      testDetachingElementKeepsEvents: function(t) {
+        var span = $('<span>').appendTo(this.el);
+        var called = false;
+        span.on('event', function() {
+          called = true;
+        });
+        span.detach();
+        span.trigger('event');
+        t.assertTrue(called);
       }
 
     })


### PR DESCRIPTION
According to the jQuery docs for remove, http://api.jquery.com/remove/,
'all bound events and jQuery data associated with the elements are removed'.
This change unbinds all events to the element before detaching it
from the DOM.
