### PR TITLE
Store event handlers on the node object

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -7,7 +7,6 @@
       slice = Array.prototype.slice,
       isFunction = $.isFunction,
       isString = function(obj){ return typeof obj == 'string' },
-      handlers = {},
       specialEvents={},
       focusinSupported = 'onfocusin' in window,
       focus = { focus: 'focusin', blur: 'focusout' },
@@ -18,10 +17,15 @@
   function zid(element) {
     return element._zid || (element._zid = _zid++)
   }
+
+  function handlers(element) {
+    return element._zhandlers || (element._zhandlers = [])
+  }
+
   function findHandlers(element, event, fn, selector) {
     event = parse(event)
     if (event.ns) var matcher = matcherFor(event.ns)
-    return (handlers[zid(element)] || []).filter(function(handler) {
+    return (handlers(element) || []).filter(function(handler) {
       return handler
         && (!event.e  || handler.e == event.e)
         && (!event.ns || matcher.test(handler.ns))
@@ -48,7 +52,7 @@
   }
 
   function add(element, events, fn, data, selector, delegator, capture){
-    var id = zid(element), set = (handlers[id] || (handlers[id] = []))
+    var id = zid(element), set = handlers(element)
     events.split(/\s/).forEach(function(event){
       if (event == 'ready') return $(document).ready(fn)
       var handler   = parse(event)
@@ -80,7 +84,7 @@
     var id = zid(element)
     ;(events || '').split(/\s/).forEach(function(event){
       findHandlers(element, event, fn, selector).forEach(function(handler){
-        delete handlers[id][handler.i]
+        delete handlers(element)[handler.i]
       if ('removeEventListener' in element)
         element.removeEventListener(realEvent(handler.e), handler.proxy, eventCapture(handler, capture))
       })


### PR DESCRIPTION
This commit stores event handlers on the `_zhandlers` properly on the
Node object instead of an object in Zepto's event library.

This has three main benefits:
1. Overall it's better for garbage collection. If a node with bound
   event listeners is being garbage collected, and the event-related
   data is stored on the node object, all that data is going to be garbage
   collected (e.g the closure and other metadata).
2. It makes it possible to use automated tools to detect memory leaks
   because they can check the `_zhandlers` properly on DOM nodes directly.
3. It makes it easier to debug DOM/listener leaks because it's clearer
   where the event listeners are stored.
