### PR TITLE
traverseNode should be using index looping rather than key looping.

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -801,7 +801,8 @@ var Zepto = (function() {
 
   function traverseNode(node, fun) {
     fun(node)
-    for (var key in node.childNodes) traverseNode(node.childNodes[key], fun)
+    for (var i = 0, len = node.childNodes.length; i < len; i++)
+      traverseNode(node.childNodes[i], fun)
   }
 
   // Generate the `after`, `prepend`, `before`, `append`,


### PR DESCRIPTION
Using key looping is not appropriate for a [NodeList](http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ID-536297177), it should be using index looping.

Key looping on a NodeList interface will also include the `item` and `length` members, which surprisingly has not created any other issues.

fixes #927
