### PR TITLE
Removing unnecessary timeouts to fix error due to event queue order

### DIFF
--- a/test/touch.html
+++ b/test/touch.html
@@ -124,12 +124,7 @@
         down(element, 10, 10)
         up(element)
 
-        t.pause()
-        setTimeout(function(){
-          t.resume(function(){
-            t.assertEqual(1, count)
-          })
-        }, 50)
+        t.assertEqual(1, count)
       },
 
       testSingleTapDoesNotInterfereWithTappingTwice: function(t){
@@ -201,14 +196,8 @@
           up(element)
 
           t.resume(function(){
-            t.pause()
-
-            setTimeout(function(){
-              t.resume(function(){
-                t.assertEqual(0, singleCount)
-                t.assertEqual(1, doubleCount)
-              })
-            }, 100)
+            t.assertEqual(0, singleCount)
+            t.assertEqual(1, doubleCount)
           })
         }, 100)
       },


### PR DESCRIPTION
Bare with me as this can be a bit difficult to explain: I am finding that in iOS the event queue can be a little slow, and the `tapend` events can fire faster than the `tapTimeout`/`swipeTimeout` callbacks.

As you can see below (ignoring the user:activity log), I am logging the `tapend` event, and the `tapTimeout` `setTimeout` callback. This was from a double tap on an iPad screen. What we should have seen is touchend > tapTimeout > touchend > tapTimeout, but instead `touchend` fired twice before the `setTimeout` callback fired. If working like expected,  as it does in a desktop browser, the `tapTimeout` would have been added to the queue and released as soon as the `touchend` callback was done executing. Instead, in Mobile Safari / UIWebView, the queue isn't released fast enough.

![mhukt3ohmtf_cot-x3wkhn7wesqxa9icjjfxgplab1o](https://f.cloud.github.com/assets/1096881/2352418/7d48f318-a58a-11e3-90a5-bfcad3da9455.png)

The problem here is that when the second `tapTimeout` callback occurs, `touch.el.trigger(event)` causes an error because the second `touchend` event sets `touch = {}`.

This doesn't actually cause the touch module to malfunction. It fires all the events correctly. However, at [Belly](https://bellycard.com), we log all of our JS errors among thousands of iPads being used constantly. As you can imagine, these errors are quite obnoxious and unnecessary.

Regardless of all of that, I don't see a need for these setTimeout's to begin with. The comments indicate that it is to prevent these events from occurring on a 'scroll', however, because the `touchend` is fired at the END of a scroll the `tapTimeout` wouldn't have been registered in the first place. Am I missing something?

Although we are not using all the events, we've been running this version in our application for a couple of months and we have seen no errors or malfunctioning. This is deployed to thousands of iPads around the country and being used by a couple hundred thousand people a week, so it's fairly well tested; Physically.

FYI: This breaks the touch tests, which I will fix if given the green light. 

_(Special thanks to @EricPKerr for the help debugging)_
