### PR TITLE
Make Zepto available for download via Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,55 @@
+{
+  "name": "zeptojs",
+  "version": "1.1.3",
+  "homepage": "http://zeptojs.com",
+  "description": "A minimalist JavaScript library for modern browsers, with a jQuery-compatible API",
+  "main": [
+    "src/zepto.js",
+    "src/event.js",
+    "src/ajax.js",
+    "src/form.js",
+    "src/ie.js",
+    "src/detect.js",
+    "src/fx.js",
+    "src/fx_methods.js",
+    "src/assets.js",
+    "src/data.js",
+    "src/deferred.js",
+    "src/callbacks.js",
+    "src/selector.js",
+    "src/touch.js",
+    "src/gesture.js",
+    "src/stack.js",
+    "src/ios3.js"
+  ],
+  "moduleType": [
+    "globals"
+  ],
+  "keywords": [
+    "javascript",
+    "event",
+    "ajax",
+    "form",
+    "ie",
+    "detect",
+    "fx",
+    "assets",
+    "data",
+    "deferred",
+    "callbacks",
+    "selector",
+    "touch",
+    "gesture",
+    "stack",
+    "ios",
+    "browser"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This battle isn't over yet. You might not have `zepto`, but you have `zeptojs` pointing to this repo, which is enough for now. I find `wget`ing libraries very annoying, multiplied by the number of files. I know this library in particular is a bit different in the sense that you build it yourself, but it is annoying as well.

You don't need to add built files to version control, you can link up source files as an array and let the users worry about compression. The choice I had to make was which files to include in `main`. I decided to include  all of them (rather than the default set). Users can deal with ignoring ones they don't need, going the other way around is more tricky. [wiredep](https://github.com/taptapship/wiredep) is a utility which is excellent for these situations. When set up, your process of installing components could look like this:

``` html
<!doctype html>
<html>
  <head>
  <!-- bower:css -->
  <!-- endbower -->
  </head>
  <body>
  <!-- bower:js -->
  <!-- endbower -->
  </body>
</html>
```

``` sh
$ bower install --save zepto modernizr normalize-css
$ gulp wiredep # or whatever you're using
```

``` html
<!doctype html>
<html>
  <head>
  <!-- bower:css -->
  <link rel="stylesheet" href="bower_components/normalize-css/normalize.css" />
  <!-- endbower -->
  </head>
  <body>
  <!-- bower:js -->
  <script src="bower_components/zeptojs/src/zepto.js"></script>
  <script src="bower_components/zeptojs/src/event.js"></script>
  <script src="bower_components/zeptojs/src/ajax.js"></script>
  <script src="bower_components/zeptojs/src/form.js"></script>
  <script src="bower_components/zeptojs/src/ie.js"></script>
  <script src="bower_components/zeptojs/src/detect.js"></script>
  <script src="bower_components/zeptojs/src/fx.js"></script>
  <script src="bower_components/zeptojs/src/fx_methods.js"></script>
  <script src="bower_components/zeptojs/src/assets.js"></script>
  <script src="bower_components/zeptojs/src/data.js"></script>
  <script src="bower_components/zeptojs/src/deferred.js"></script>
  <script src="bower_components/zeptojs/src/callbacks.js"></script>
  <script src="bower_components/zeptojs/src/selector.js"></script>
  <script src="bower_components/zeptojs/src/touch.js"></script>
  <script src="bower_components/zeptojs/src/gesture.js"></script>
  <script src="bower_components/zeptojs/src/stack.js"></script>
  <script src="bower_components/zeptojs/src/ios3.js"></script>
  <!-- endbower -->
  </body>
</html>
```

Compare that to `wget`.

Now, if I want to exclude some Zepto files, I can [configure](https://github.com/taptapship/wiredep#configuration) wiredep to exclude them. Then I just run `gulp wiredep` and everything is updated.

(Sure, Bower is a bit clumsy, but it's getting there.)
