### PR TITLE
Fix getter/setter detection in .attr and .prop to use arguments.length

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -598,7 +598,7 @@ var Zepto = (function() {
     },
     attr: function(name, value){
       var result
-      return (typeof name == 'string' && value === undefined) ?
+      return (typeof name == 'string' && arguments.length == 1) ?
         (this.length == 0 || this[0].nodeType !== 1 ? undefined :
           (name == 'value' && this[0].nodeName == 'INPUT') ? this.val() :
           (!(result = this[0].getAttribute(name)) && name in this[0]) ? this[0][name] : result
@@ -614,14 +614,19 @@ var Zepto = (function() {
     },
     prop: function(name, value){
       name = propMap[name] || name
-      return (value === undefined) ?
+      return (arguments.length == 1) ?
         (this[0] && this[0][name]) :
         this.each(function(idx){
           this[name] = funcArg(this, value, idx, this[name])
         })
     },
     data: function(name, value){
-      var data = this.attr('data-' + name.replace(capitalRE, '-$1').toLowerCase(), value)
+      name = name.replace(capitalRE, '-$1').toLowerCase()
+      
+      var data = arguments.length == 1 ?
+        this.attr('data-' + name) :
+        this.attr('data-' + name, value)
+
       return data !== null ? deserializeValue(data) : undefined
     },
     val: function(value){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1682,6 +1682,9 @@
         })
         t.assertEqual('0id', els.attr('data-id'))
         t.assertEqual('1id', $('#attr_2').attr('data-id'))
+        
+        t.assertEqual(els, els.attr('data-undef', undefined));
+        t.assertEqual(undefined, els.attr('data-undef'));
       },
 
       testProp: function(t){
@@ -1704,6 +1707,11 @@
         t.assertEqual(td2.prop('colspan'), 2)
         t.assertEqual(img.prop('usemap'), '#imgMap')
         t.assertEqual(div.prop('contenteditable'), 'true')
+        
+        input.prop('readonly', false);
+        t.assertEqual(input.prop('readonly'), false);
+        
+        t.assertEqual(input, input.prop('maxlength', undefined));
       },
 
       testAttrNoElement: function(t){
@@ -1792,6 +1800,10 @@
         // blank values
         t.assertIdentical('', el.data('empty'))
         t.assertUndefined(el.data('does-not-exist'))
+        
+        // acts as a setter with 2nd parameter undefined
+        t.assertEqual(el, el.data('undef', undefined))
+        t.assertEqual(undefined, el.data('undef'));
       },
 
       testDataNumberType: function(t){


### PR DESCRIPTION
Fixes madrobby/zepto#942

This is to match jQuery's behavior:

``` js
// Is now a setter instead of a getter
$("#el").attr('value',undefined);
```
