### PR TITLE
fix #950, find with falsy values should returns empty array

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -472,7 +472,8 @@ var Zepto = (function() {
     },
     find: function(selector){
       var result, $this = this
-      if (typeof selector == 'object')
+      if (!selector) result = []
+      else if (typeof selector == 'object')
         result = $(selector).filter(function(){
           var node = this
           return emptyArray.some.call($this, function(parent){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1385,6 +1385,18 @@
         t.assertEqual('1', found.get(0).innerHTML)
       },
 
+      testFindWithFalsyValue: function(t){
+        var element = '<div><a>1</a></div>';
+        var found = $(element).find(undefined)
+        t.assertLength(0, found)
+        found = $(element).find(false)
+        t.assertLength(0, found)
+        found = $(element).find(0)
+        t.assertLength(0, found)
+        found = $(element).find('')
+        t.assertLength(0, found)
+      },
+
       testFilter: function(t){
         var found = $('div')
         t.assertLength(2, found.filter('.filtertest'))


### PR DESCRIPTION
Fix #950.
Relative test added.
Before the patch, it throws an Error: `TypeError: 'undefined' is not an object`.
