### PR TITLE
fix #939, .attr('value') should differs from .val() on <input>

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -601,7 +601,6 @@ var Zepto = (function() {
       var result
       return (typeof name == 'string' && value === undefined) ?
         (this.length == 0 || this[0].nodeType !== 1 ? undefined :
-          (name == 'value' && this[0].nodeName == 'INPUT') ? this.val() :
           (!(result = this[0].getAttribute(name)) && name in this[0]) ? this[0][name] : result
         ) :
         this.each(function(idx){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1750,7 +1750,9 @@
         values = $.map(inputs, function(i){ return $(i).attr('value') })
         t.assertEqual('Default input, Text input, Email input, Search input', values.join(', '))
 
-        inputs.val(function(i, value){ return value.replace('input', 'changed') })
+        // Only .attr('value', v) changes .attr('value')
+        // rather than .val(v)
+        inputs.attr('value', function(i, value){ return value.replace('input', 'changed') })
 
         values = $.map(inputs, function(i){ return $(i).attr('value') })
         t.assertEqual('Default changed, Text changed, Email changed, Search changed', values.join(', '))
@@ -1872,6 +1874,26 @@
 
         t.assertEqualCollection(['2'], multiple.val(),
           "Expected val() to reflect changes to selected options in a <select multiple> element")
+      },
+
+      testValVsValueAttr: function(t) {
+        var input
+
+        input = $('<input type="text" value="Original">')
+        input.val('By .val(v)')
+        t.assertEqual('Original', input.attr('value'))
+        t.assertEqual('By .val(v)', input.val())
+
+        input.attr('value', 'By .attr("value", v)')
+        t.assertEqual('By .attr("value", v)', input.attr('value'))
+        t.assertEqual('By .val(v)', input.val())
+
+        // .attr('value', v) will change both
+        // without applying .val(v) first
+        input = $('<input type="text" value="Original">')
+        input.attr('value', 'By .attr("value", v)')
+        t.assertEqual('By .attr("value", v)', input.attr('value'))
+        t.assertEqual('By .attr("value", v)', input.val())
       },
 
       testChaining: function(t){


### PR DESCRIPTION
Fix #939. 

With the patch, **Zepto** gets more consistent with **jQuery**.
There should be no detecting on `<input>` in method `.attr()`.

> ~~`(name == 'value' && this[0].nodeName == 'INPUT') ? this.val() :`~~
- ~~`.val()` does not influence `.attr('value')`~~
- ~~however, once `.attr('value')` changes, `.val()` changes too~~
- usually, `.attr('value')` > `.val()` - .attr('value', v) would change both
- however, once after applying `.val(v)`, `.attr('value')` and `.val()` separates to manage their own

~~Priority: `.attr('value')` > `.val()`~~
