### PR TITLE
Add $.noop

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -338,6 +338,7 @@ var Zepto = (function() {
   $.uuid = 0
   $.support = { }
   $.expr = { }
+  $.noop = function() {}
 
   $.map = function(elements, callback){
     var value, values = [], i, key

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -809,6 +809,12 @@
         t.assertEqual(1, index)
       },
 
+      testNoop: function(t){
+        t.assert($.isFunction($.noop))
+        t.assertEqual($.noop.length, 0)
+        t.assertEqual($.noop(), undefined)
+      },
+
       testMap: function(t){
         var results = $('#eachtest > *').map(function(idx, el) {
           t.assertIdentical(el, this)


### PR DESCRIPTION
Adds a noop method, which does nothing.

Two reasons to add this method:
1. noop is useful to have, every now and again
2. jQuery uses $.noop and this will further improve compatibility

Not urgent, obviously.
