### PR TITLE
Moved variable 'el' declaration into inner scope

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -4,10 +4,10 @@
 
 ;(function($){
   $.fn.serializeArray = function() {
-    var result = [], el
+    var el, type, result = []
     $([].slice.call(this.get(0).elements)).each(function(){
       el = $(this)
-      var type = el.attr('type')
+      type = el.attr('type')
       if (this.nodeName.toLowerCase() != 'fieldset' &&
         !this.disabled && type != 'submit' && type != 'reset' && type != 'button' &&
         ((type != 'radio' && type != 'checkbox') || this.checked))


### PR DESCRIPTION
Moving the `var el` declaration into the function scope where it is used makes for more readable (understandable) code.

It might also help the JS code generators when optimizing the code (haven't tested that, though).
