### PR TITLE
fix deserilize issue

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -310,7 +310,7 @@ var Zepto = (function() {
         value == "true" ||
         ( value == "false" ? false :
           value == "null" ? null :
-          !/^0/.test(value) && !isNaN(num = Number(value)) ? num :
+          !/^0|^\s/.test(value) && !isNaN(num = Number(value)) ? num :
           /^[\[\{]/.test(value) ? $.parseJSON(value) :
           value )
         : value


### PR DESCRIPTION
if html structure like &lt;li data-name=" " id="test">&lt;/li&gt; or &lt;li data-name="  9" id="test"&gt;&lt;/li&gt;, just one or more blank, then $('#test').data('name') will get value 0 or 9, not ' ' or '  9'.
so i fixed this issue
