### PR TITLE
fix tap event break through bug

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -113,7 +113,7 @@
           }, 0)
 
         // normal tap
-        else if ('last' in touch)
+        else if ('last' in touch){
           // don't fire tap when delta position changed by more than 30 pixels,
           // for instance when moving to a point and back to origin
           if (deltaX < 30 && deltaY < 30) {
@@ -125,7 +125,6 @@
               // (cancelTouch cancels processing of single vs double taps for faster 'tap' response)
               var event = $.Event('tap')
               event.cancelTouch = cancelAll
-              touch.el.trigger(event)
 
               // trigger double tap immediately
               if (touch.isDoubleTap) {
@@ -145,6 +144,15 @@
           } else {
             touch = {}
           }
+	}
+		
+          var event = $.Event('tap');
+          event.cancelTouch = cancelAll;
+          touch.el.trigger(event);
+	  if( $(e.target).height() == 0 ){
+	  	e.preventDefault();
+	  }
+		
           deltaX = deltaY = 0
 
       })

--- a/src/touch.js
+++ b/src/touch.js
@@ -113,7 +113,7 @@
           }, 0)
 
         // normal tap
-        else if ('last' in touch){
+        else if ('last' in touch)
           // don't fire tap when delta position changed by more than 30 pixels,
           // for instance when moving to a point and back to origin
           if (deltaX < 30 && deltaY < 30) {
@@ -125,6 +125,7 @@
               // (cancelTouch cancels processing of single vs double taps for faster 'tap' response)
               var event = $.Event('tap')
               event.cancelTouch = cancelAll
+          	  touch.el.trigger(event);
 
               // trigger double tap immediately
               if (touch.isDoubleTap) {
@@ -144,14 +145,10 @@
           } else {
             touch = {}
           }
-	}
-		
-          var event = $.Event('tap');
-          event.cancelTouch = cancelAll;
-          touch.el.trigger(event);
-	  if( $(e.target).height() == 0 ){
-	  	e.preventDefault();
-	  }
+		  
+	  	  if( $(e.target).height() == 0 ){
+	  		e.preventDefault();
+	  	  }
 		
           deltaX = deltaY = 0
 


### PR DESCRIPTION
when tap , the event will break through top layer, trigger on the bottom layer.
that order w3c  Capture and bubbling  Event trigger mechanism , but I still think that is touch event's bug .

Area B and C below the area A, when to click in the C area (under A cover layer), will find that move on to the baidu page, that is, click A originally, but through A, click on the link in the C! 

For example:
  http://www.xinshuocms.com/test/demo.html

Cause of the bug : 
    In the DOM tree, A is the parent of C, before the bubble to C it, leave the user hand touch screen and the screen is to trigger the click event, (according to the rules of the click event, only when triggered, currently has, according to the click event of the element and users in facing the front, just click event triggered) due to click delay, now has A hidden, satisfy the following C click event trigger condition, and then click event was triggered .so that called "点透"

test : 
  This page is tested on the mi 2s(android 4.2) and apply 5c(ios 7) 