### PR TITLE
(refactor) remove redundant check

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -678,7 +678,7 @@ var Zepto = (function() {
           return element.style[camelize(property)] || computedStyle.getPropertyValue(property)
         else if (isArray(property)) {
           var props = {}
-          $.each(isArray(property) ? property: [property], function(_, prop){
+          $.each(property, function(_, prop){
             props[prop] = (element.style[camelize(prop)] || computedStyle.getPropertyValue(prop))
           })
           return props


### PR DESCRIPTION
Looks like this check is totally unnecessary - we've just checked that the argument is an array, so `isArray(property)` on this line should always return true.
