### PR TITLE
Fix likeArray

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -74,7 +74,7 @@ var Zepto = (function() {
   function isPlainObject(obj) {
     return isObject(obj) && !isWindow(obj) && Object.getPrototypeOf(obj) == Object.prototype
   }
-  function likeArray(obj) { return typeof obj.length == 'number' }
+  function likeArray(obj) { return obj && typeof obj.length == 'number' }
 
   function compact(array) { return filter.call(array, function(item){ return item != null }) }
   function flatten(array) { return array.length > 0 ? $.fn.concat.apply([], array) : array }


### PR DESCRIPTION
``` js
//function likeArray(obj) { return typeof obj.length == 'number' }
function likeArray(obj) { return obj && typeof obj.length == 'number' }
```

So it will never throw error like "Uncaught TypeError: Cannot read property 'length' of null"
