### PR TITLE
Update detect.js

### DIFF
--- a/src/detect.js
+++ b/src/detect.js
@@ -3,8 +3,9 @@
 //     Zepto.js may be freely distributed under the MIT license.
 
 ;(function($){
-  function detect(ua){
-    var os = this.os = {}, browser = this.browser = {},
+  function detect(nav){
+    var ua = nav.userAgent, plat = nav.platform,
+      os = this.os = {}, browser = this.browser = {},
       webkit = ua.match(/Web[kK]it[\/]{0,1}([\d.]+)/),
       android = ua.match(/(Android);?[\s\/]+([\d.]+)?/),
       osx = !!ua.match(/\(Macintosh\; Intel /),
@@ -12,6 +13,7 @@
       ipod = ua.match(/(iPod)(.*OS\s([\d_]+))?/),
       iphone = !ipad && ua.match(/(iPhone\sOS)\s([\d_]+)/),
       webos = ua.match(/(webOS|hpwOS)[\s\/]([\d.]+)/),
+      win = plat.match(/Win\d{2}|Windows/), // No Safari for WinCE or PocketPC, platform member more reliable than ua
       wp = ua.match(/Windows Phone ([\d.]+)/),
       touchpad = webos && ua.match(/TouchPad/),
       kindle = ua.match(/Kindle\/([\d.]+)/),
@@ -51,7 +53,7 @@
     if (chrome) browser.chrome = true, browser.version = chrome[1]
     if (firefox) browser.firefox = true, browser.version = firefox[1]
     if (ie) browser.ie = true, browser.version = ie[1]
-    if (safari && (osx || os.ios)) {browser.safari = true; if (osx) browser.version = safari[1]}
+    if (safari && (osx || os.ios || win)) {browser.safari = true; if (osx) browser.version = safari[1]}
     if (webview) browser.webview = true
 
     os.tablet = !!(ipad || playbook || (android && !ua.match(/Mobile/)) ||
@@ -61,7 +63,7 @@
       (firefox && ua.match(/Mobile/)) || (ie && ua.match(/Touch/))))
   }
 
-  detect.call($, navigator.userAgent)
+  detect.call($, window.navigator)
   // make available to unit tests
   $.__detect = detect
 


### PR DESCRIPTION
Add Windows to the list of Safari tests to ensure recognition in Windows.
