### PR TITLE
Serialize is not correct

### DIFF
--- a/src/form.js
+++ b/src/form.js
@@ -8,7 +8,7 @@
     $([].slice.call(this.get(0).elements)).each(function(){
       el = $(this)
       type = el.attr('type')
-      if (this.nodeName.toLowerCase() != 'fieldset' &&
+      if (this.name && this.nodeName.toLowerCase() != 'fieldset' &&
         !this.disabled && type != 'submit' && type != 'reset' && type != 'button' &&
         ((type != 'radio' && type != 'checkbox') || this.checked))
         result.push({


### PR DESCRIPTION
Form elements must be submitable. There must be a `name` attribute, otherwise it will submit some useless character.

``` html
<form>
    <input type="text" name="foo" value="bar">
    <input type="text">
    <input type="text">
    <input type="text">
</form>
```

This is not correct

``` js
$('form').serialize();
// foo=bar&=&=&=
```

The determination method of `jQuery`, (serializeArray)

``` js
this.name && !jQuery( this ).is( ":disabled" ) &&
rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
( this.checked || !rcheckableType.test( type ) )
```
