### PR TITLE
fix  deserializeValue overflow problem

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -310,7 +310,7 @@ var Zepto = (function() {
         value == "true" ||
         ( value == "false" ? false :
           value == "null" ? null :
-          !/^0/.test(value) && !isNaN(num = Number(value)) ? num :
+          !/^0/.test(value) && !isNaN(num = Number(value)) && String(num) === value ? num :
           /^[\[\{]/.test(value) ? $.parseJSON(value) :
           value )
         : value


### PR DESCRIPTION
deserializeValue ("5903509451651483504") return unexpected  5903509451651484000 because of overflowing of the integer
I add the condition that checks if overflowing occured to fix the function deserializeValue overflow problem.
