### PR TITLE
Fix #1023: Without ie-module css() on empty selection causes type error ...

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -672,8 +672,9 @@ var Zepto = (function() {
     },
     css: function(property, value){
       if (arguments.length < 2) {
-        var element = this[0], computedStyle = getComputedStyle(element, '')
+        var element = this[0]
         if(!element) return
+        computedStyle = getComputedStyle(element, '')
         if (typeof property == 'string')
           return element.style[camelize(property)] || computedStyle.getPropertyValue(property)
         else if (isArray(property)) {


### PR DESCRIPTION
...in Firefox

Firefox (like IE) throws an error, if window.getComputedStyle is called with
an invalid argument.

getComputedStyle was called, before the argument was checked. This caused an
error,if css() was called on an empty selection.
