### PR TITLE
Added AMD output to build, `npm run-script dist-amd`.

### DIFF
--- a/make
+++ b/make
@@ -32,17 +32,27 @@ target[zepto_gz] = ->
   target.compress() if stale(zepto_gz, zepto_min)
 
 target.dist = ->
-  target.build()
+  target.build(false)
+  target.minify()
+  target.compress()
+ 
+target.amd = ->
+  target.build(true)
   target.minify()
   target.compress()
 
-target.build = ->
+target.build = (amd) ->
   cd __dirname
   mkdir '-p', 'dist'
   modules = (env['MODULES'] || 'zepto event ajax form ie').split(' ')
   module_files = ( "src/#{module}.js" for module in modules )
-  intro = "/* Zepto #{describe_version()} - #{modules.join(' ')} - zeptojs.com/license */\n"
-  dist = (intro + cat(module_files).replace(/^\/[\/*].*$/mg, '')).replace(/\n{3,}/g, "\n\n")
+  if amd
+	  intro = "/* Zepto #{describe_version()} - #{modules.join(' ')} - zeptojs.com/license */\ndefine(function(){\nvar amd=true;\n"
+	  outro = "return Zepto;});"
+  else
+	  intro = "/* Zepto #{describe_version()} - #{modules.join(' ')} - zeptojs.com/license */\n"
+	  outro = ""
+  dist = (intro + cat(module_files).replace(/^\/[\/*].*$/mg, '') + outro).replace(/\n{3,}/g, "\n\n")
   dist.to(zepto_js)
   report_size(zepto_js)
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   , "scripts": {
       "test": "coffee make test"
     , "dist": "coffee make dist"
+	, "dist-amd": "coffee make amd"
     , "start": "coffee test/server.coffee"
   }
   , "repository": "madrobby/zepto"

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -881,6 +881,8 @@ var Zepto = (function() {
   return $
 })()
 
-// If `$` is not yet defined, point it to `Zepto`
-window.Zepto = Zepto
-window.$ === undefined && (window.$ = Zepto)
+if(!amd) {
+	// If `$` is not yet defined, point it to `Zepto`
+	window.Zepto = Zepto
+	window.$ === undefined && (window.$ = Zepto)
+}


### PR DESCRIPTION
Not the prettiest code (definitely a hack), but it adds better support for AMD via something like require.js.
