### PR TITLE
Bug about an empty array returned by Zepto#find(somethingFalsey)

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -478,7 +478,7 @@ var Zepto = (function() {
     },
     find: function(selector){
       var result, $this = this
-      if (!selector) result = []
+      if (!selector) result = $()
       else if (typeof selector == 'object')
         result = $(selector).filter(function(){
           var node = this


### PR DESCRIPTION
Now, `Zepto#find(somethingFalsey)` return a pure empty array.
But I think `Zepto#find(somethingFalsey)` should return a `$()`.

Because:
- We expect `Zepto#find` to return a collection
  
  In [the official documents](http://zeptojs.com/#find), we can not understand that "`Zepto#find` can return a pure array".
- jQuery compatibility (for v1.11.1 and v2.1.1)
  
  I got `$()` by executing `$(elem).find(undefined)` on jQuery v1.11.1 and v2.1.1.
