### PR TITLE
To fixed the bug of INVALID_STATE_ERR: DOM Exception 11

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -263,10 +263,10 @@
       return xhr
     }
 
-    if (settings.xhrFields) for (name in settings.xhrFields) xhr[name] = settings.xhrFields[name]
-
     var async = 'async' in settings ? settings.async : true
     xhr.open(settings.type, settings.url, async, settings.username, settings.password)
+    
+    if (settings.xhrFields) for (name in settings.xhrFields) xhr[name] = settings.xhrFields[name]
 
     for (name in headers) nativeSetHeader.apply(xhr, headers[name])
 


### PR DESCRIPTION
When set the xhr.withCredentials = true before xhr.open, there will get an exception of INVALID_STATE_ERR: DOM Exception 11.

resolved method:  
  set xhr.withCredentials = true after xhr.open

OS: Android 4.2.2
