### PR TITLE
Parse location.href with an anchor for IE

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -196,6 +196,7 @@
     if (!settings.crossDomain) {
       urlAnchor = document.createElement('a')
       urlAnchor.href = settings.url
+      urlAnchor.href = urlAnchor.href
       settings.crossDomain = (originAnchor.protocol + '//' + originAnchor.host) !== (urlAnchor.protocol + '//' + urlAnchor.host)
     }
 


### PR DESCRIPTION
This is a follow up to https://github.com/madrobby/zepto/pull/1046. It turns out that IE always adds the port to `window.location.host`, but not to `a.host`. This doesn't show up in tests because they are run on port 3000, so the port is always present in `a.host` too.
