### PR TITLE
remove useless variables & support setting duration value as a quotation mark wrapped number (such as '2000')

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -3,9 +3,9 @@
 //     Zepto.js may be freely distributed under the MIT license.
 
 ;(function($, undefined){
-  var prefix = '', eventPrefix, endEventName, endAnimationName,
+  var prefix = '', eventPrefix,
     vendors = { Webkit: 'webkit', Moz: '', O: 'o' },
-    document = window.document, testEl = document.createElement('div'),
+    testEl = document.createElement('div'),
     supportedTransforms = /^((translate|rotate|scale)(X|Y|Z|3d)?|matrix(3d)?|perspective|skew(X|Y)?)$/i,
     transform,
     transitionProperty, transitionDuration, transitionTiming, transitionDelay,
@@ -48,8 +48,17 @@
       callback = ease, ease = undefined
     if ($.isPlainObject(duration))
       ease = duration.easing, callback = duration.complete, delay = duration.delay, duration = duration.duration
-    if (duration) duration = (typeof duration == 'number' ? duration :
-                    ($.fx.speeds[duration] || $.fx.speeds._default)) / 1000
+    if (duration){
+      if(typeof duration == 'string' && $.fx.speeds.hasOwnProperty(duration)){
+        duration = $.fx.speeds[duration]
+      }else{
+        duration = parseFloat(duration,10) // support `number-string` , e.g. `'500'`
+        if(isNaN(duration)){
+          duration = $.fx.speeds._default
+        }
+      }
+      duration /= 1000
+    }
     if (delay) delay = parseFloat(delay) / 1000
     return this.anim(properties, duration, ease, callback, delay)
   }


### PR DESCRIPTION
In `.animate`

jQuery support `duration` set  as a _quotation mark wrapped number_ (such as `'2000'` , string). the behavior as same as it set to `2000` ,number.

But Zepto not support that yet . 

This is the pull request mainly for.

---

By the way,

```
endEventName, endAnimationName,
```

are not been used , so remove them.

---

And 

```
document = window.document,
```

used only once for the following code :

```
testEl = document.createElement('div'),
```

is not that important, so also can be removed.
