### PR TITLE
support setting duration value as a quotation mark wrapped number (such as '2000')

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -48,8 +48,17 @@
       callback = ease, ease = undefined
     if ($.isPlainObject(duration))
       ease = duration.easing, callback = duration.complete, delay = duration.delay, duration = duration.duration
-    if (duration) duration = (typeof duration == 'number' ? duration :
-                    ($.fx.speeds[duration] || $.fx.speeds._default)) / 1000
+    if (duration){
+      if(typeof duration == 'string' && $.fx.speeds.hasOwnProperty(duration)){
+        duration = $.fx.speeds[duration]
+      }else{
+        duration = parseFloat(duration,10) // support `duration` set as a quotation mark wrapped number (such as '2000' , string)
+        if(isNaN(duration)){
+          duration = $.fx.speeds._default
+        }
+      }
+      duration /= 1000
+    }
     if (delay) delay = parseFloat(delay) / 1000
     return this.anim(properties, duration, ease, callback, delay)
   }


### PR DESCRIPTION
jQuery support `duration` set  as a _quotation mark wrapped number_ (such as _string_ `'2000'` ). the behavior as same as it set to _number_ `2000` .

But Zepto not support that yet. 

It has been well tested by myself.

_This is a independent pull request for duration enhancement in #1059_