### PR TITLE
Accept function as data for on event handler

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -182,7 +182,7 @@
 
     if (!isString(selector) && !isFunction(callback) && callback !== false)
       callback = data, data = selector, selector = undefined
-    if (isFunction(data) || data === false)
+    if (callback === undefined || data === false)
       callback = data, data = undefined
 
     if (callback === false) callback = returnFalse

--- a/test/event.html
+++ b/test/event.html
@@ -274,6 +274,21 @@
         t.assertEqual(1, numArgs)
         t.assertIdentical(data, gotData)
       },
+      
+      testHandlerWithFunctionAsData: function(t){
+        var data = function () { console.log('foo') },
+            gotData, numArgs
+        
+        $(document).on('click', data, function(event){
+          gotData = event.data
+          numArgs = arguments.length
+        })
+        t.assertUndefined(gotData)
+
+        click(this.el)
+        t.assertEqual(1, numArgs)
+        t.assertIdentical(data, gotData)
+      },
 
       testDelegatedWithData: function(t){
         var data = {}, gotData, numArgs


### PR DESCRIPTION
Move the parameter data to callback, if callback is undefined or data is
false. As the data can hold any type, including function, the check is
done on the callback, to see if it is undefined, before moving the
parameters.

Fixes #1042