### PR TITLE
add support for JSON.stringify object when contentType is json

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -180,7 +180,10 @@
   // serialize payload and append it to the URL for GET requests
   function serializeData(options) {
     if (options.processData && options.data && $.type(options.data) != "string")
-      options.data = $.param(options.data, options.traditional)
+      if (options.contentType && isJSON(options.contentType))
+        options.data = JSON.stringify(options.data)
+      else
+        options.data = $.param(options.data, options.traditional)
     if (options.data && (!options.type || options.type.toUpperCase() == 'GET'))
       options.url = appendQuery(options.url, options.data), options.data = undefined
   }
@@ -360,5 +363,9 @@
     }
     serialize(params, obj, traditional)
     return params.join('&').replace(/%20/g, '+')
+  }
+
+  function isJSON(contentType){
+    return typeof contentType == 'string' && contentType.toLowerCase().indexOf('application/json') == 0;
   }
 })(Zepto)

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -322,6 +322,23 @@
         })
       },
 
+      testAjaxPostJSON: function(t){
+        t.pause()
+        resumeOnAjaxError(t)
+
+        $.ajax({
+          url: 'create',
+          type: 'POST',
+          data: { hello: 'world' },
+          dataType: 'json',
+          contentType: 'application/json',
+          headers: { accept: 'application/json' },
+          success: t.reg.resumeHandler('success', function(data){
+            t.assertEqual('world', data.payload.hello)
+          })
+        })
+      },
+
       testAjaxGetJSON: function(t){
         t.pause()
         resumeOnAjaxError(t)


### PR DESCRIPTION
for now, I must do this every time.

```js
$.ajax({
  url: 'some',
  type: 'POST',
  data: JSON.stringify({ hello: 'world' }), // JSON.stringify should be done by zepto
  dataType: 'json',
  contentType: 'application/json',
  success: ...
)}
```