### PR TITLE
Android 2.3 $.parseJSON with NULL argument throws "Uncaught illegal access" exception

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -380,7 +380,7 @@ var Zepto = (function() {
     return filter.call(elements, callback)
   }
 
-  if (window.JSON) $.parseJSON = JSON.parse
+  if (window.JSON) $.parseJSON = function(data){ return JSON.parse(data + "") }
 
   // Populate the class2type map
   $.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(i, name) {


### PR DESCRIPTION
android 2.3 `JSON.parse` with NULL argument, it throws "Uncaught illegal access" exception and causes JavaScript to stop execution.

here are some discussions <https://code.google.com/p/android/issues/detail?id=11973>

