### PR TITLE
Fix error in offset call on IE10

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -678,6 +678,8 @@ var Zepto = (function() {
         $this.css(props)
       })
       if (!this.length) return null
+      if (!$.contains(document.documentElement, this[0]))
+        return {top: 0, left: 0}
       var obj = this[0].getBoundingClientRect()
       return {
         left: obj.left + window.pageXOffset,

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1095,6 +1095,7 @@
         t.assertNull($('#doesnotexist').offset())
         var el = $('#some_element')
         t.assertIdentical(el, el.offset({}))
+        t.assertSame($('<div>').offset(), {left: 0, top: 0})
       },
 
       testWidth: function(t){


### PR DESCRIPTION
Calling `.getBoundingClientRect` on elements not in the DOM throws an `Unspecified error` on IE 10, what I did here is the same approach used by [jQuery's offset](https://github.com/jquery/jquery/blob/74ae5444832b2fb966768a97281d2ad8c088bc58/src/offset.js#L97-L99) implementation.