### PR TITLE
Fix likeArray

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -74,7 +74,7 @@ var Zepto = (function() {
   function isPlainObject(obj) {
     return isObject(obj) && !isWindow(obj) && Object.getPrototypeOf(obj) == Object.prototype
   }
-  function likeArray(obj) { return typeof obj.length == 'number' }
+  function likeArray(obj) { return isArray(obj) }
 
   function compact(array) { return filter.call(array, function(item){ return item != null }) }
   function flatten(array) { return array.length > 0 ? $.fn.concat.apply([], array) : array }


### PR DESCRIPTION
likeArray returns true on an object with a length property containing a number.

using $.each on { 'length': 20 } fails