### PR TITLE
add comment about `urlAnchor.href` self assignment

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -196,6 +196,7 @@
     if (!settings.crossDomain) {
       urlAnchor = document.createElement('a')
       urlAnchor.href = settings.url
+      // cleans up URL for .href (IE only), see https://github.com/madrobby/zepto/pull/1049
       urlAnchor.href = urlAnchor.href
       settings.crossDomain = (originAnchor.protocol + '//' + originAnchor.host) !== (urlAnchor.protocol + '//' + urlAnchor.host)
     }


### PR DESCRIPTION
This comment is added to avoid future question about `urlAnchor.href` self assignment, see #1085.