### PR TITLE
Pseudo element-support in getComputedStyle wrapper

### DIFF
--- a/src/ie.js
+++ b/src/ie.js
@@ -9,9 +9,9 @@
     getComputedStyle(undefined)
   } catch(e) {
     var nativeGetComputedStyle = getComputedStyle;
-    window.getComputedStyle = function(element){
+    window.getComputedStyle = function(element, pseudoElt){
       try {
-        return nativeGetComputedStyle(element)
+        return nativeGetComputedStyle(element, pseudoElt)
       } catch(e) {
         return null
       }


### PR DESCRIPTION
Both Firefox and IE browsers freak out when called without valid arguments, which means that getComputedStyled will be wrapped by the comparability-layer. However, getComputedStyle has support for an optional second parameter (`pseudoElt`) which allows you to get the computed style of pseudo-elements. This patch fixes the wrapper so that this second argument is passed to the native implementation instead of silently being dropped.

See https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle for info on the second argument.