### PR TITLE
Ajax: Add support for receiving binary data (bug)

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -250,17 +250,23 @@
         var result, error = false
         if ((xhr.status >= 200 && xhr.status < 300) || xhr.status == 304 || (xhr.status == 0 && protocol == 'file:')) {
           dataType = dataType || mimeToDataType(settings.mimeType || xhr.getResponseHeader('content-type'))
-          result = xhr.responseText
+          
+          if (xhr.responseType == 'arraybuffer' || xhr.responseType == 'blob')
+            result = xhr.response
+          else {
+            result = xhr.responseText
 
-          try {
-            // http://perfectionkills.com/global-eval-what-are-the-options/
-            if (dataType == 'script')    (1,eval)(result)
-            else if (dataType == 'xml')  result = xhr.responseXML
-            else if (dataType == 'json') result = blankRE.test(result) ? null : $.parseJSON(result)
-          } catch (e) { error = e }
+            try {
+              // http://perfectionkills.com/global-eval-what-are-the-options/
+              if (dataType == 'script')    (1,eval)(result)
+              else if (dataType == 'xml')  result = xhr.responseXML
+              else if (dataType == 'json') result = blankRE.test(result) ? null : $.parseJSON(result)
+            } catch (e) { error = e }
 
-          if (error) ajaxError(error, 'parsererror', xhr, settings, deferred)
-          else ajaxSuccess(result, xhr, settings, deferred)
+            if (error) return ajaxError(error, 'parsererror', xhr, settings, deferred)
+          }
+
+          ajaxSuccess(result, xhr, settings, deferred)
         } else {
           ajaxError(xhr.statusText || null, xhr.status ? 'error' : 'abort', xhr, settings, deferred)
         }


### PR DESCRIPTION
> The `responseText` property of the XMLHttpRequest object can be set to change the expected response type from the server.

See: [MDN Sending and Receiving Binary Data](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data)

The `responseText` property **should not be accessed**, when the `responseType` enumerated value of the XMLHttpRequest object has been set to `arraybuffer` or `binary`.

Accessing the `responseText` value of an `arraybuffer` XMLHttpRequest throws an error (see below).

Example:

```
    $.ajax({
      url: 'http://joeschmoe.org/image.png',
      timeout: 1000,
      beforeSend: function(xhr) {
        xhr.responseType = 'arraybuffer';

        return xhr;
      },
      success: function(response) {
        // Response type is ArrayBuffer (native XMLHttpRequest)
        var data = new Uint8Array(response);
        // ...
      }
    });
```

Error:

```sh
Uncaught InvalidStateError: Failed to read the 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text' (was 'arraybuffer').
```

Additional details:

The default `responseType` value is an empty string:

> `XMLHttpRequest.responseType`
> `""`	DOMString (this is the default value)

See: [MDN XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#xmlhttprequest-responsetype)

:white_check_mark: Tested with:

* Firefox 27 (Firefox OS `1.3`)
* Google Chrome (Android KitKat `4.4`)