### PR TITLE
Optimize and fix ios3 String.prototype.trim

### DIFF
--- a/src/ios3.js
+++ b/src/ios3.js
@@ -4,7 +4,8 @@
 
 ;(function(undefined){
   if (String.prototype.trim === undefined) // fix for iOS 3.2
-    String.prototype.trim = function(){ return this.replace(/^\s+|\s+$/g, '') }
+    var rtrim = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g
+    String.prototype.trim = function(){ return this.replace(rtrim, '') }
 
   // For iOS 3.x
   // from https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/reduce


### PR DESCRIPTION
Having the regex inside the function means it's creating a new regex object each time someone runs trim, moving it outside the function reduces memory consumption and improves speed.

Also replaced the regex itself with the [MDN recommendation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Polyfill) to more closely match the native implementation.