### PR TITLE
in Android webview, long press will fire touchmove, cause longTap event not work

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -94,7 +94,7 @@
         touch.x2 = firstTouch.pageX
         touch.y2 = firstTouch.pageY
         // in Android webview, long press will fire touchmove, cause longTap event not work
-        if(Math.abs(touch.x1 - touch.x2) > 15 && Math.abs(touch.y1 - touch.y2) > 15){
+        if(Math.abs(touch.x1 - touch.x2) > 5 || Math.abs(touch.y1 - touch.y2) > 5){
           cancelLongTap()
         }
 

--- a/src/touch.js
+++ b/src/touch.js
@@ -90,9 +90,13 @@
         if((_isPointerType = isPointerEventType(e, 'move')) &&
           !isPrimaryTouch(e)) return
         firstTouch = _isPointerType ? e : e.touches[0]
-        cancelLongTap()
+
         touch.x2 = firstTouch.pageX
         touch.y2 = firstTouch.pageY
+        // in Android webview, long press will fire touchmove, cause longTap event not work
+        if(Math.abs(touch.x1 - touch.x2) > 15 && Math.abs(touch.y1 - touch.y2) > 15){
+          cancelLongTap()
+        }
 
         deltaX += Math.abs(touch.x1 - touch.x2)
         deltaY += Math.abs(touch.y1 - touch.y2)


### PR DESCRIPTION
bugfix: Android webview, zepto.js longTap event not work