### PR TITLE
fix fx.js dasherize  function bug

### DIFF
--- a/src/fx.js
+++ b/src/fx.js
@@ -12,7 +12,7 @@
     animationName, animationDuration, animationTiming, animationDelay,
     cssReset = {}
 
-  function dasherize(str) { return str.replace(/([a-z])([A-Z])/, '$1-$2').toLowerCase() }
+  function dasherize(str) { return str.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase() }
   function normalizeEvent(name) { return eventPrefix ? eventPrefix + name : name.toLowerCase() }
 
   $.each(vendors, function(vendor, event){


### PR DESCRIPTION
fix fx.js dasherize function bug
It would return `backgorund-positiony` for `BackgroundPositionY`.

Now it can transform properties like `BackgroundPositionY` correctly.