### PR TITLE
Skip copying webkitMovementX/Y

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -119,7 +119,7 @@
 
   var returnTrue = function(){return true},
       returnFalse = function(){return false},
-      ignoreProperties = /^([A-Z]|returnValue$|layer[XY]$)/,
+      ignoreProperties = /^([A-Z]|returnValue$|layer[XY]$|webkitMovement[XY]$)/,
       eventMethods = {
         preventDefault: 'isDefaultPrevented',
         stopImmediatePropagation: 'isImmediatePropagationStopped',


### PR DESCRIPTION
The following warnings are observed in Chrome 45.0 and 47.0 (OSX):
`'webkitMovementX' is deprecated. Please use 'movementX' instead.`

`webkitMovementX/Y` seem to be deprecated in Chrome 45+, so skip copying them.
This fix eliminates these warnings.