### PR TITLE
Changing emptyArray

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -3,7 +3,19 @@
 //     Zepto.js may be freely distributed under the MIT license.
 
 var Zepto = (function() {
-  var undefined, key, $, classList, emptyArray = [], concat = emptyArray.concat, filter = emptyArray.filter, slice = emptyArray.slice,
+  var undefined, key, $, classList, emptyArray = {
+          slice: [].slice,
+          filter: [].filter,
+          indexOf: [].indexOf,
+          forEach:  [].forEach,
+          reduce: [].reduce,
+          push: [].push,
+          sort: [].sort,
+          concat: [].concat,
+          every: [].every,
+          some: [].some
+    }, 
+    concat = emptyArray.concat, filter = emptyArray.filter, slice = emptyArray.slice,
     document = window.document,
     elementDisplay = {}, classCache = {},
     cssNumber = { 'column-count': 1, 'columns': 1, 'font-weight': 1, 'line-height': 1,'opacity': 1, 'z-index': 1, 'zoom': 1 },


### PR DESCRIPTION
When using zepto and prototype (for example) changes Array Mathods. With that fix you can run them together.