### PR TITLE
fixes css batch setting on non-existing element, fixes #1145

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -690,18 +690,20 @@ var Zepto = (function() {
     },
     css: function(property, value){
       if (arguments.length < 2) {
-        var computedStyle, element = this[0]
-        if(!element) return
-        computedStyle = getComputedStyle(element, '')
-        if (typeof property == 'string')
-          return element.style[camelize(property)] || computedStyle.getPropertyValue(property)
-        else if (isArray(property)) {
+        var element = this[0]
+        if (typeof property == 'string') {
+          if (!element) return
+          return element.style[camelize(property)] || getComputedStyle(element, '').getPropertyValue(property)
+        } else if (isArray(property)) {
+          if (!element) return
           var props = {}
+          var computedStyle = getComputedStyle(element, '')
           $.each(property, function(_, prop){
             props[prop] = (element.style[camelize(prop)] || computedStyle.getPropertyValue(prop))
           })
           return props
-        }
+        } else if (!element)
+          return this
       }
 
       var css = ''

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1661,6 +1661,15 @@
         t.assert(!errorWasRaised)
       },
 
+      testCSSBatchSetOnNonExistingElementReturnsSelf: function (t) {
+        var el = $('.some-non-exist-elm')
+        var ret = el.css({
+          'border': '2px solid #000',
+          'color': 'rgb(0,255,0)'
+        })
+        t.assertEqual(ret, el)
+      },
+
       testHtml: function(t){
         var div = $('div.htmltest');
 


### PR DESCRIPTION
- fixes `$().css({height:1}).css({height:1})`
- adds test cases
- fixes #1145

Have tried my best to obey the original coding style. Duplicate `getComputedStyle(element, '')`, but it will not become much larger after compressing.