### PR TITLE
text() returns text from all matching selectors instead of just the first one

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -618,7 +618,7 @@ var Zepto = (function() {
           var newText = funcArg(this, text, idx, this.textContent)
           this.textContent = newText == null ? '' : ''+newText
         }) :
-        (0 in this ? this[0].textContent : null)
+        (0 in this ? this.pluck('textContent').join("") : null)
     },
     attr: function(name, value){
       var result

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1716,15 +1716,18 @@
         $('#texttest3').text(undefined)
         t.assertEqual('', $('#texttest3').text())
 
-        t.assertEqual('Here is some text', $('div.texttest').text())
+        t.assertEqual('Here is some text', $('#texttest1').text())
         t.assertEqual('And some more', $('#texttest2').text())
+        
+        // gets all text of selectors matching
+        t.assertEqual('Here is some textAnd some more', $('div.texttest').text())
 
         $('div.texttest').text("Let's set it")
         t.assertEqual("Let's set it", $('#texttest1').text())
         t.assertEqual("Let's set it", $('#texttest2').text())
 
         $('#texttest2').text('')
-        t.assertEqual("Let's set it", $('div.texttest').text())
+        t.assertEqual("Let's set it", $('#texttest1').text())
         t.assertEqual('', $('#texttest2').text())
       },
 


### PR DESCRIPTION
Previously it only returned the text from the first item matching the selector passed. 
Now it returns the text concatenated from all selectors matching the selector passed. 
#1142