### PR TITLE
add delete event handlers on html,remove,text,empty

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -270,4 +270,41 @@
     return compatible(event)
   }
 
+  // fix `remove()、empty()、text()、html()` delete Event of handlers
+  ;(function() {
+    // delete handlers from $element
+    function clearEvent($element) {
+      $element.map(function() {
+        return this._zid
+      }).forEach(function(id) {
+        // If contains events
+        if (id && handlers[id]) delete handlers[id]
+      })
+    }
+
+    ;('empty remove').split(' ').forEach(function(val) {
+      var _old = $.fn[val]
+      $.fn[val] = function(text) {
+        var $element = this.find('*')
+        // If it is remove, it contains the current element.
+        if (val === 'remove') $element = $element.add(this)
+
+        clearEvent($element)
+
+        return _old.call(this)
+      }
+    })
+
+    ;('html text').split(' ').forEach(function(val) {
+      var _old = $.fn[val]
+      $.fn[val] = function(text) {
+        // If there is no parameter
+        return arguments.length === 0 ?
+          _old.call(this) :
+          clearEvent(this.find('*')), _old.apply(this, arguments)
+      }
+    })
+  })()
+
+
 })(Zepto)

--- a/src/event.js
+++ b/src/event.js
@@ -274,9 +274,8 @@
   ;(function() {
     // delete handlers from $element
     function clearEvent($element) {
-      $element.map(function() {
-        return this._zid
-      }).forEach(function(id) {
+      $element.each(function() {
+        var id = this._zid
         // If contains events
         if (id && handlers[id]) delete handlers[id]
       })

--- a/test/event.html
+++ b/test/event.html
@@ -467,6 +467,83 @@
       }
 
     })
+
+    // Due to delete event rewritten empty,html,text,remove, so after testing the method is effective binding events
+    Evidence('DeleteEvent', {
+      setUp: function(){
+        this.el = $('<div />').appendTo('#fixtures')
+      },
+
+      appendDom: function() {
+        this.el.html('<a><b>1</b></a><b></b><b></b>').find('b').on('click hover change', false)
+      },
+
+      tearDown: function() {
+        this.el.off().remove()
+      },
+
+      testEmpty: function(t) {
+        this.appendDom()
+        this.el.empty()
+
+        this.appendDom()
+        this.el.parent().empty()
+
+        this.appendDom()
+        this.el.empty()
+      },
+
+      testHtml: function(t) {
+        this.appendDom()
+        this.el.html()
+
+        this.appendDom()
+        this.el.html('')
+
+        this.appendDom()
+        this.el.parent().html()
+
+        this.appendDom()
+        this.el.parent().html('')
+
+        this.appendDom()
+        this.el.html()
+
+        this.appendDom()
+        this.el.html('')
+      },
+
+      testText: function(t) {
+        this.appendDom()
+        this.el.text()
+
+        this.appendDom()
+        this.el.text('')
+
+        this.appendDom()
+        this.el.parent().text()
+
+        this.appendDom()
+        this.el.parent().text('')
+
+        this.appendDom()
+        this.el.text()
+
+        this.appendDom()
+        this.el.text('')
+      },
+
+      testRemove: function(t) {
+        this.appendDom()
+        this.el.remove()
+
+        this.appendDom()
+        this.el.parent().remove()
+
+        this.appendDom()
+        this.el.remove()
+      }
+    })
   })()
   </script>
 </body>


### PR DESCRIPTION
When you delete elements, although identification (_zid) put the elements on the deleted, but the presence of handlers in the event queue has not been deleted, where covered under html, remove, empty, text methods, and their characteristics for each method demand to delete handlers～Thank you

---

As shown in the case of deletion:
![image](https://cloud.githubusercontent.com/assets/3872051/12217151/088ea2ae-b733-11e5-82c3-c5e5c357ebe0.png)
