### PR TITLE
Convert null/undefined into "" in $.fn.val() for jQuery compatibility

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -655,14 +655,17 @@ var Zepto = (function() {
       return data !== null ? deserializeValue(data) : undefined
     },
     val: function(value){
-      return 0 in arguments ?
-        this.each(function(idx){
+      if (value == null) value = ""
+      if (0 in arguments) {
+        return this.each(function(idx){
           this.value = funcArg(this, value, idx, this.value)
-        }) :
-        (this[0] && (this[0].multiple ?
-           $(this[0]).find('option').filter(function(){ return this.selected }).pluck('value') :
-           this[0].value)
+        })
+      } else {
+        return (this[0] && (this[0].multiple ?
+          $(this[0]).find('option').filter(function(){ return this.selected }).pluck('value') :
+          this[0].value)
         )
+      }
     },
     offset: function(coordinates){
       if (coordinates) return this.each(function(index){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1979,7 +1979,7 @@
         t.assertEqual('Hello World', input.val())
 
         input.val(undefined);
-        t.assertEqual('undefined', input.val());
+        t.assertEqual('', input.val());
 
         input.val('')
         t.assertEqual('', input.val())


### PR DESCRIPTION
`$.fn.val(null)` or `$.fn.val(undefined)` sets the value to a blank string with jQuery, but sets to string `"undefined"` with Zepto.
This patch fixes this incompatibility.

```js
$('input[type=text]').val('foo');
$('input[type=text]').val(); // => "foo"
$('input[type=text]').val(null);

// Zepto.js v1.1.6
$('input[type=text]').val(); // => "undefined"
// jQuery v1.12.0 and v2.2.0
$('input[type=text]').val(); // => ""
```