### PR TITLE
fixes offset() on documentElement, related to #1158

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -678,7 +678,7 @@ var Zepto = (function() {
         $this.css(props)
       })
       if (!this.length) return null
-      if (!$.contains(document.documentElement, this[0]))
+      if (document.documentElement !== this[0] && !$.contains(document.documentElement, this[0]))
         return {top: 0, left: 0}
       var obj = this[0].getBoundingClientRect()
       return {

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -143,7 +143,7 @@
   </ul>
 
   <ul id="contentsTest">1<span>2</span><span id="contentsEmptyTest"></span></ul>
-  
+
   <iframe id="contentsIframeTest" src="fixtures/iframe_document.html"></iframe>
 
   <ul id="siblingsTest">
@@ -290,7 +290,7 @@
         return html
       })(node)
     }
-    
+
     function testDocumentFragmentOrShadowRootContext($fragment, t) {
       t.assertLength(1, $fragment)
       t.assertEqual(Node.DOCUMENT_FRAGMENT_NODE, $fragment.get(0).nodeType)
@@ -947,11 +947,11 @@
       testDollarParseJSON: function(t) {
         t.assertSame({a:'b'}, $.parseJSON('{"a":"b"}'))
       },
-      
+
       testDollarWithDocumentFragmentContext: function(t){
         testDocumentFragmentOrShadowRootContext($(document.createDocumentFragment()), t)
       },
-      
+
       testDollarWithShadowRootContext: function(t){
         if ('createShadowRoot' in document.body) {
           var $subject = $('#test_dollar_with_shadow_root')
@@ -1096,6 +1096,14 @@
         var el = $('#some_element')
         t.assertIdentical(el, el.offset({}))
         t.assertSame($('<div>').offset(), {left: 0, top: 0})
+      },
+
+      testOffsetOnHTML: function(t){
+        var offset = $('html').offset()
+        t.assertEqual(offset.left, 0)
+        t.assertEqual(offset.top, 0)
+        t.assert('width' in offset)
+        t.assert('height' in offset)
       },
 
       testWidth: function(t){
@@ -1251,7 +1259,7 @@
         t.assertLength(2, $contents.filter('span'))
         t.assertLength(0, $("#contentsEmptyTest").contents())
       },
-      
+
       testIframeContents: function(t){
         var el = $("#contentsIframeTest")
         t.assertEqual("Hello from iframe!", el.contents().find("b").first().text())
@@ -1718,7 +1726,7 @@
 
         t.assertEqual('Here is some text', $('#texttest1').text())
         t.assertEqual('And some more', $('#texttest2').text())
-        
+
         // gets all text of selectors matching
         t.assertEqual('Here is some textAnd some more', $('div.texttest').text())
 
@@ -1884,12 +1892,12 @@
         el.removeAttr('data-name')
         t.assertNull(el.attr('data-name'))
       },
-      
+
       testRemoveMultipleAttr: function(t) {
         var el = $('#attr_remove_multi')
         t.assertEqual('someId1', el.attr('data-id'))
         t.assertEqual('someName1', el.attr('data-name'))
-        
+
         el.removeAttr('data-id data-name')
         t.assertNull(el.attr('data-id'))
         t.assertNull(el.attr('data-name'))


### PR DESCRIPTION
- fixes `offset()` on `document.documentElement`, which also affected `$('html').width()`, related to #1158
- removes some trailing whitespaces in test/zepto.html