### PR TITLE
originalCallback could be undefined

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -100,7 +100,7 @@
         ajaxSuccess(responseData[0], xhr, options, deferred)
       }
 
-      window[callbackName] = originalCallback
+      window[callbackName] = originalCallback || empty
       if (responseData && $.isFunction(originalCallback))
         originalCallback(responseData[0])
 


### PR DESCRIPTION
Under a scenario, when ajax request was aborted, and response was not arrived, then window[ callbackName ] would be restored to originalCallback.

When response was arrived, this would invoke an error, because originalCallback could be undefined.