### PR TITLE
Added datafilter option to Zepto ajax.js.

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -71,6 +71,12 @@
     ajaxStop(settings)
   }
 
+  function ajaxDataFilter(data, type, settings) {
+    if (settings.dataFilter == empty) return data
+    var context = settings.context
+    return settings.dataFilter.call(context, data, type)
+  }
+
   // Empty function, used as default callback
   function empty() {}
 
@@ -161,7 +167,11 @@
     // Whether data should be serialized to string
     processData: true,
     // Whether the browser should be allowed to cache GET responses
-    cache: true
+    cache: true,
+    //Used to handle the raw response data of XMLHttpRequest.
+    //This is a pre-filtering function to sanitize the response.
+    //The sanitized response should be returned
+    dataFilter: empty
   }
 
   function mimeToDataType(mime) {
@@ -258,6 +268,8 @@
 
             try {
               // http://perfectionkills.com/global-eval-what-are-the-options/
+              // sanitize response accordingly if data filter callback provided
+              result = ajaxDataFilter(result, dataType, settings)
               if (dataType == 'script')    (1,eval)(result)
               else if (dataType == 'xml')  result = xhr.responseXML
               else if (dataType == 'json') result = blankRE.test(result) ? null : $.parseJSON(result)

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -322,6 +322,23 @@
         })
       },
 
+      testAjaxDataFilterJSON: function(t){
+        t.pause()
+        resumeOnAjaxError(t)
+
+        $.ajax({
+          url: 'taintedJSON',
+          dataFilter: function(data, type) {
+            if (!data) return
+            return data.replace(/^\s*while\(1\);\s*/, '')
+          },
+          headers: { accept: 'application/json' },
+          success: t.reg.resumeHandler('success', function(data){
+            t.assertEqual('world', data.hello)
+          })
+        })
+      },
+
       testAjaxGetJSON: function(t){
         t.pause()
         resumeOnAjaxError(t)

--- a/test/server.coffee
+++ b/test/server.coffee
@@ -83,6 +83,10 @@ app.get '/test/json', (req, res) ->
   else
     res.send 400, 'FAIL'
 
+app.get '/test/taintedJSON', (req, res) ->
+  res.set 'Content-Type', 'application/json'
+  res.send 'while(1);{"hello" : "world"}'
+
 app.post '/test/create', (req, res) ->
   res.json
     action: 'created'


### PR DESCRIPTION
Original Issue: https://github.com/madrobby/zepto/issues/1194 . I did not get any objections, so I went for it. Should work the same as it would on jQuery. I tried to keep my changes compliant to the Zepto StyleGuide. 

I appreciate any feedback. Let me know if you have any concerns. 

I ran all tests, with the addition of the tests I added, they all pass. 

Thanks!