### PR TITLE
Enable AMD-compatible module output

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,6 @@ This will submit a pull request to us that we can review.
    platform information. For better formatting of your report, see
    [GitHub-flavored Markdown][mkd].
 
-### Help! It doesn't work in browserify!
-
-We have received complaints about not supporting popular JavaScript module loaders countless times. [Here](https://github.com/madrobby/zepto/pull/342#issuecomment-3006524) is a short explanation of our decision. A good JS loader should have a way to shim libraries which don't follow the CommonJS/AMD/UMD pattern.
-
-[Here is an example](https://github.com/silvenon/zepto-module-demo) of shimming Zepto for browserify, allowing you to easily import only needed modules while leaving the source code untouched.
-
 ### Running tests
 
 You will need to install [PhantomJS][]. On OS X, that's easy:

--- a/make
+++ b/make
@@ -42,8 +42,9 @@ target.build = ->
   modules = (env['MODULES'] || 'zepto event ajax form ie').split(' ')
   module_files = ( "src/#{module}.js" for module in modules )
   intro = "/* Zepto #{describe_version()} - #{modules.join(' ')} - zeptojs.com/license */\n"
-  dist = (intro + cat(module_files).replace(/^\/[\/*].*$/mg, '')).replace(/\n{3,}/g, "\n\n")
-  dist.to(zepto_js)
+  dist = cat(module_files).replace(/^\/[\/*].*$/mg, '').replace(/\n{3,}/g, "\n\n")
+  dist = cat('src/amd_layout.js').replace(/YIELD/, -> dist.trim()) unless env['NOAMD']
+  (intro + dist).to(zepto_js)
   report_size(zepto_js)
 
 target.minify = ->

--- a/src/amd_layout.js
+++ b/src/amd_layout.js
@@ -1,0 +1,9 @@
+(function(global, factory) {
+  if (typeof define === 'function' && define.amd)
+    define(function() { return factory(global) })
+  else
+    factory(global)
+}(this, function(window) {
+  YIELD
+  return Zepto
+}))


### PR DESCRIPTION
When a module loader is present at runtime, this wraps Zepto as an anonymous module. It still exports `Zepto` and `$` to the global namespace when imported, though, to keep compatibility with plugins that expect it there. This is [akin to what jQuery does](https://github.com/jquery/jquery/pull/557).

With no module loader, zepto.js executes normally.

Opt out of this AMD shim by setting `NOAMD=1` environment variable.

References #342, #797 #1030 #1039;
fixes #1052, fixes #955, fixes #900, fixes #751, fixes #708.