### PR TITLE
Add `make publish` target for npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+*
+!README.md
+!MIT-LICENSE
+!dist/zepto.js
+!dist/zepto.min.js
+!src/*.js
+src/amd_layout.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "zepto"
   , "version": "1.1.6"
+  , "main": "dist/zepto.js"
   , "homepage": "http://zeptojs.com"
   , "scripts": {
       "test": "coffee make test"


### PR DESCRIPTION
This improves our npm package. The release process is now:

1. Bump version number in only 1 location, `package.json`;
2. Create a tagged commit `vX.Y.Z` that matches package.json;
3. `./make publish`.