### PR TITLE
identify ajax error types: error abort timeout

### DIFF
--- a/test/ajax.html
+++ b/test/ajax.html
@@ -1443,6 +1443,10 @@
         MockXHR.last.abort()
         MockXHR.last.ready(4, 0, 'Aborted')
 
+        // abort needs to fire abort event
+        MockXHR.last.onabort();
+        
+
         setTimeout(function(){
           t.resume(function(){
             t.assertFalse(successFired)

--- a/test/ajax.html
+++ b/test/ajax.html
@@ -1444,7 +1444,7 @@
         MockXHR.last.ready(4, 0, 'Aborted')
 
         // abort needs to fire abort event
-        MockXHR.last.onabort();
+        MockXHR.last.onabort()
         
 
         setTimeout(function(){


### PR DESCRIPTION
According to specification, ajax errors can be error, abort, timeout with different events. But Zepto handles them with 'abort' error. This pull request fixed to identify ajax errors just like jQuery.
