### PR TITLE
Ordering of parameters is actually (index, item)

### DIFF
--- a/core/_posts/1900-01-01-Z-map.md
+++ b/core/_posts/1900-01-01-Z-map.md
@@ -1,7 +1,7 @@
 ---
 title: $.map
 signature: |
-  $.map(collection, function(item, index){ ... }) ⇒ collection
+  $.map(collection, function(index, item){ ... }) ⇒ collection
 ---
 
 Iterate through elements of collection and return all results of running the


### PR DESCRIPTION
Hi there - saw there was a minor error in the docs for Zepto's map() function, thought it best to correct it myself!