### PR TITLE
Catch exception while assigning `event.timeStamp`

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -139,7 +139,9 @@
         event[predicate] = returnFalse
       })
 
-      event.timeStamp || (event.timeStamp = Date.now())
+      try {
+        event.timeStamp || (event.timeStamp = Date.now())
+      } catch (ignored) { }
 
       if (source.defaultPrevented !== undefined ? source.defaultPrevented :
           'returnValue' in source ? source.returnValue === false :


### PR DESCRIPTION
The `event.timeStamp` property is considered readonly by safari on iOS
(iOS 9.3.4, Safari 9) and assigning it throws an error which effectively
disables at least `.on()` and `.click()` listeners. This fixes #1209.