### PR TITLE
Change amd_layout.js to support CommonJs

### DIFF
--- a/src/amd_layout.js
+++ b/src/amd_layout.js
@@ -1,9 +1,16 @@
 (function(global, factory) {
-  if (typeof define === 'function' && define.amd)
+  if (typeof module === "object" && typeof module.exports === "object" )
+    module.exports = global.document
+      ? factory(global, true)
+      : function(w) {
+        if (!w.document) throw new Error( "Zepto requires a window with a document" )
+        return factory(w)
+      }
+  else if (typeof define === 'function' && define.amd)
     define(function() { return factory(global) })
   else
     factory(global)
-}(this, function(window) {
+}(typeof window !== "undefined" ? window : this, function(window) {
   YIELD
   return Zepto
 }))


### PR DESCRIPTION
[JS still sucks in 2016](https://hackernoon.com/how-it-feels-to-learn-javascript-in-2016-d3a717dd577f), but module bundler like webpack, browserify or other bundler depend on CommonJs are very popular.

Zepto is the most popular javascript lib in mobile browser. We use webpack import and bundle dependencies to make the web site more fast, more cacheable and more stable. But when I import zepto, I found zepto is not support CommonJs. It makes me a lot of trouble, and must [do more thing](https://sebastianblade.com/how-to-import-unmodular-library-like-zepto/) to make zepto like a CommonJs module.

So we need zepto to be modular as CommonJs. Please~ 😊 @mislav 
