### PR TITLE
fix touch event and pointer event trigger at the same time in browser which support both

### DIFF
--- a/src/touch.js
+++ b/src/touch.js
@@ -122,7 +122,6 @@
         deltaY += Math.abs(touch.y1 - touch.y2)
       })
       .on(touchEventMap.up, function(e){
-        debugger;
         if((_isPointerType = isPointerEventType(e, 'up')) &&
           !isPrimaryTouch(e)) return
         cancelLongTap()

--- a/src/touch.js
+++ b/src/touch.js
@@ -15,7 +15,7 @@
           move: 'touchmove',
           cancel: 'touchcancel'
         }
-      }else if('onponinterdown' in document){
+      }else if('onpointerdown' in document){
         return {
           down: 'pointerdown',
           up: 'pointerup',
@@ -122,6 +122,7 @@
         deltaY += Math.abs(touch.y1 - touch.y2)
       })
       .on(touchEventMap.up, function(e){
+        debugger;
         if((_isPointerType = isPointerEventType(e, 'up')) &&
           !isPrimaryTouch(e)) return
         cancelLongTap()

--- a/src/touch.js
+++ b/src/touch.js
@@ -6,7 +6,31 @@
   var touch = {},
     touchTimeout, tapTimeout, swipeTimeout, longTapTimeout,
     longTapDelay = 750,
-    gesture
+    gesture,
+    touchEventMap = function(){
+      if('ontouchstart' in document){
+        return {
+          down: 'touchstart',
+          up: 'touchend',
+          move: 'touchmove',
+          cancel: 'touchcancel'
+        }
+      }else if('onponinterdown' in document){
+        return {
+          down: 'pointerdown',
+          up: 'pointerup',
+          move: 'pointermove',
+          cancel: 'pointercancel'
+        }
+      }else if('onmspointerdown' in document){
+        return {
+          down: 'MSPointerDown',
+          up: 'MSPointerUP',
+          move: 'MSPointerMove',
+          cancel: 'MSPointerCancel'
+        }
+      }
+    }()
 
   function swipeDirection(x1, x2, y1, y2) {
     return Math.abs(x1 - x2) >=
@@ -63,7 +87,7 @@
           touch.el.trigger('swipe'+ swipeDirectionFromVelocity)
         }
       })
-      .on('touchstart MSPointerDown pointerdown', function(e){
+      .on(touchEventMap.down, function(e){
         if((_isPointerType = isPointerEventType(e, 'down')) &&
           !isPrimaryTouch(e)) return
         firstTouch = _isPointerType ? e : e.touches[0]
@@ -86,7 +110,7 @@
         // adds the current touch contact for IE gesture recognition
         if (gesture && _isPointerType) gesture.addPointer(e.pointerId)
       })
-      .on('touchmove MSPointerMove pointermove', function(e){
+      .on(touchEventMap.move, function(e){
         if((_isPointerType = isPointerEventType(e, 'move')) &&
           !isPrimaryTouch(e)) return
         firstTouch = _isPointerType ? e : e.touches[0]
@@ -97,7 +121,7 @@
         deltaX += Math.abs(touch.x1 - touch.x2)
         deltaY += Math.abs(touch.y1 - touch.y2)
       })
-      .on('touchend MSPointerUp pointerup', function(e){
+      .on(touchEventMap.up, function(e){
         if((_isPointerType = isPointerEventType(e, 'up')) &&
           !isPrimaryTouch(e)) return
         cancelLongTap()
@@ -154,7 +178,7 @@
       // when the browser window loses focus,
       // for example when a modal dialog is shown,
       // cancel all ongoing events
-      .on('touchcancel MSPointerCancel pointercancel', cancelAll)
+      .on(touchEventMap.cancel, cancelAll)
 
     // scrolling the window indicates intention of the user
     // to scroll, not tap or swipe, so cancel all ongoing events

--- a/test/touch.html
+++ b/test/touch.html
@@ -118,6 +118,7 @@
         var count = 0, element = $('#test').get(0)
 
         $('#test').on('tap', function(){
+          console.log('tap');
           count++
         })
 
@@ -132,205 +133,205 @@
         }, 50)
       },
 
-      testScrollDoesNotFireTap: function(t){
-        var element = $('#test').get(0), count = 0
-
-        $('#test').on('tap', function () {
-          count++
-        })
-
-        down(element, 0, 0)
-        move(element, 0, 20)
-        move(element, 0, 20)
-        up(element)
-
-        t.pause()
-        setTimeout(function(){
-          t.resume(function(){
-            t.assertEqual(0, count)
-          })
-        }, 50)
-      },
-
-      testSingleTapDoesNotInterfereWithTappingTwice: function(t){
-        var count = 0, element = $('#test').get(0)
-
-        $('#test').on('tap', function(){
-          count++
-        })
-
-        down(element, 10, 10)
-        up(element)
-
-        t.pause()
-        setTimeout(function(){
-          down(element, 10, 10)
-          up(element)
-
-          t.resume(function(){
-            t.pause()
-
-            setTimeout(function(){
-              t.resume(function(){
-                t.assertEqual(2, count)
-              })
-            }, 200)
-          })
-        }, 200)
-      },
-
-      // should be fired if there is one tap within 250ms
-      testSingleTap: function(t){
-        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
-
-        $('#test').on('singleTap', function(){
-          singleCount++
-        }).on('doubleTap', function(){
-          doubleCount++
-        })
-
-        down(element, 10, 10)
-        up(element)
-
-        t.pause()
-        setTimeout(function(){
-          t.resume(function(){
-            t.assertEqual(1, singleCount)
-            t.assertEqual(0, doubleCount)
-          })
-        }, 300)
-      },
-
-      // should be fired if there are two taps within 250ms
-      testDoubleTap: function(t){
-        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
-
-        $('#test').on('singleTap', function(){
-          singleCount++
-        }).on('doubleTap', function(){
-          doubleCount++
-        })
-
-        down(element, 10, 10)
-        up(element)
-
-        t.pause()
-        setTimeout(function(){
-          down(element, 12, 12)
-          up(element)
-
-          t.resume(function(){
-            t.pause()
-
-            setTimeout(function(){
-              t.resume(function(){
-                t.assertEqual(0, singleCount)
-                t.assertEqual(1, doubleCount)
-              })
-            }, 100)
-          })
-        }, 100)
-      },
-
-      // should be fired if the finger is down in the same location for >750ms
-      testLongTap: function(t){
-        var count = 0, element = $('#test').get(0)
-
-        $('#test').on('longTap', function(){
-          count++
-        })
-
-        down(element, 10, 10)
-
-        t.pause()
-        setTimeout(function(){
-          up(element)
-
-          t.resume(function(){
-            t.assertEqual(1, count)
-          })
-        }, 900)
-      },
-
-      testLongTapDoesNotFireIfFingerIsMoved: function(t){
-        var count = 0, element = $('#test').get(0)
-
-        $('#test').on('longTap', function(){
-          count++
-        })
-
-        down(element, 10, 10)
-
-        t.pause()
-        setTimeout(function(){
-          move(element, 50, 10)
-          t.resume(function(){
-            t.pause()
-            setTimeout(function(){
-              up(element)
-              t.resume(function(){
-                t.assertEqual(0, count)
-              })
-            }, 450)
-          })
-        }, 450)
-      },
-
-      testSwipe: function(t){
-        var swipeCount = 0, element = $('#test').get(0)
-
-        $('#test').on('swipe', function(){
-          swipeCount++
-        })
-
-        down(element, 10, 10)
-
-        t.pause()
-        setTimeout(function(){
-          move(element, 70, 10)
-          up(element)
-
-          t.resume(function(){
-            t.pause()
-
-            setTimeout(function(){
-              t.resume(function(){
-                t.assertEqual(1, swipeCount)
-              })
-            }, 50)
-          })
-        }, 50)
-      },
-
-      testTapDoNotFireWhenMoveToPointAndBack: function (t) {
-        var tapCount = 0, element = $('#test').get(0)
-
-        $('#test').on('tap', function(){
-          tapCount++
-        })
-        down(element, 10, 10)
-        move(element, 60, 10)
-
-        t.pause()
-        setTimeout(function(){
-          t.resume(function(){
-            move(element, 10, 10)
-            up(element)
-            t.pause()
-            setTimeout(function(){
-              t.resume( function () {
-                t.assertEqual(0, tapCount)
-              })
-            }, 100)
-          })
-        }, 100)
-      }
+//      testScrollDoesNotFireTap: function(t){
+//        var element = $('#test').get(0), count = 0
+//
+//        $('#test').on('tap', function () {
+//          count++
+//        })
+//
+//        down(element, 0, 0)
+//        move(element, 0, 20)
+//        move(element, 0, 20)
+//        up(element)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          t.resume(function(){
+//            t.assertEqual(0, count)
+//          })
+//        }, 50)
+//      },
+//
+//      testSingleTapDoesNotInterfereWithTappingTwice: function(t){
+//        var count = 0, element = $('#test').get(0)
+//
+//        $('#test').on('tap', function(){
+//          count++
+//        })
+//
+//        down(element, 10, 10)
+//        up(element)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          down(element, 10, 10)
+//          up(element)
+//
+//          t.resume(function(){
+//            t.pause()
+//
+//            setTimeout(function(){
+//              t.resume(function(){
+//                t.assertEqual(2, count)
+//              })
+//            }, 200)
+//          })
+//        }, 200)
+//      },
+//
+//      // should be fired if there is one tap within 250ms
+//      testSingleTap: function(t){
+//        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
+//
+//        $('#test').on('singleTap', function(){
+//          singleCount++
+//        }).on('doubleTap', function(){
+//          doubleCount++
+//        })
+//
+//        down(element, 10, 10)
+//        up(element)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          t.resume(function(){
+//            t.assertEqual(1, singleCount)
+//            t.assertEqual(0, doubleCount)
+//          })
+//        }, 300)
+//      },
+//
+//      // should be fired if there are two taps within 250ms
+//      testDoubleTap: function(t){
+//        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
+//
+//        $('#test').on('singleTap', function(){
+//          singleCount++
+//        }).on('doubleTap', function(){
+//          doubleCount++
+//        })
+//
+//        down(element, 10, 10)
+//        up(element)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          down(element, 12, 12)
+//          up(element)
+//
+//          t.resume(function(){
+//            t.pause()
+//
+//            setTimeout(function(){
+//              t.resume(function(){
+//                t.assertEqual(0, singleCount)
+//                t.assertEqual(1, doubleCount)
+//              })
+//            }, 100)
+//          })
+//        }, 100)
+//      },
+//
+//      // should be fired if the finger is down in the same location for >750ms
+//      testLongTap: function(t){
+//        var count = 0, element = $('#test').get(0)
+//
+//        $('#test').on('longTap', function(){
+//          count++
+//        })
+//
+//        down(element, 10, 10)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          up(element)
+//
+//          t.resume(function(){
+//            t.assertEqual(1, count)
+//          })
+//        }, 900)
+//      },
+//
+//      testLongTapDoesNotFireIfFingerIsMoved: function(t){
+//        var count = 0, element = $('#test').get(0)
+//
+//        $('#test').on('longTap', function(){
+//          count++
+//        })
+//
+//        down(element, 10, 10)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          move(element, 50, 10)
+//          t.resume(function(){
+//            t.pause()
+//            setTimeout(function(){
+//              up(element)
+//              t.resume(function(){
+//                t.assertEqual(0, count)
+//              })
+//            }, 450)
+//          })
+//        }, 450)
+//      },
+//
+//      testSwipe: function(t){
+//        var swipeCount = 0, element = $('#test').get(0)
+//
+//        $('#test').on('swipe', function(){
+//          swipeCount++
+//        })
+//
+//        down(element, 10, 10)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          move(element, 70, 10)
+//          up(element)
+//
+//          t.resume(function(){
+//            t.pause()
+//
+//            setTimeout(function(){
+//              t.resume(function(){
+//                t.assertEqual(1, swipeCount)
+//              })
+//            }, 50)
+//          })
+//        }, 50)
+//      },
+//
+//      testTapDoNotFireWhenMoveToPointAndBack: function (t) {
+//        var tapCount = 0, element = $('#test').get(0)
+//
+//        $('#test').on('tap', function(){
+//          tapCount++
+//        })
+//        down(element, 10, 10)
+//        move(element, 60, 10)
+//
+//        t.pause()
+//        setTimeout(function(){
+//          t.resume(function(){
+//            move(element, 10, 10)
+//            up(element)
+//            t.pause()
+//            setTimeout(function(){
+//              t.resume( function () {
+//                t.assertEqual(0, tapCount)
+//              })
+//            }, 100)
+//          })
+//        }, 100)
+//      }
 
       // TODO: test swipes in specific directions
     }
 
-    Evidence('TouchTest',     $.extend({ emitEvent: emitTouchEvent }, tests))
-    Evidence('MSPointerTest', $.extend({ emitEvent: emitMSPointerEvent }, tests))
+//    Evidence('TouchTest',     $.extend({ emitEvent: emitTouchEvent }, tests))
+//    Evidence('MSPointerTest', $.extend({ emitEvent: emitMSPointerEvent }, tests))
     Evidence('PointerTest',   $.extend({ emitEvent: emitPointerEvent }, tests))
   })()
   </script>

--- a/test/touch.html
+++ b/test/touch.html
@@ -118,7 +118,6 @@
         var count = 0, element = $('#test').get(0)
 
         $('#test').on('tap', function(){
-          console.log('tap');
           count++
         })
 
@@ -133,205 +132,205 @@
         }, 50)
       },
 
-//      testScrollDoesNotFireTap: function(t){
-//        var element = $('#test').get(0), count = 0
-//
-//        $('#test').on('tap', function () {
-//          count++
-//        })
-//
-//        down(element, 0, 0)
-//        move(element, 0, 20)
-//        move(element, 0, 20)
-//        up(element)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          t.resume(function(){
-//            t.assertEqual(0, count)
-//          })
-//        }, 50)
-//      },
-//
-//      testSingleTapDoesNotInterfereWithTappingTwice: function(t){
-//        var count = 0, element = $('#test').get(0)
-//
-//        $('#test').on('tap', function(){
-//          count++
-//        })
-//
-//        down(element, 10, 10)
-//        up(element)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          down(element, 10, 10)
-//          up(element)
-//
-//          t.resume(function(){
-//            t.pause()
-//
-//            setTimeout(function(){
-//              t.resume(function(){
-//                t.assertEqual(2, count)
-//              })
-//            }, 200)
-//          })
-//        }, 200)
-//      },
-//
-//      // should be fired if there is one tap within 250ms
-//      testSingleTap: function(t){
-//        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
-//
-//        $('#test').on('singleTap', function(){
-//          singleCount++
-//        }).on('doubleTap', function(){
-//          doubleCount++
-//        })
-//
-//        down(element, 10, 10)
-//        up(element)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          t.resume(function(){
-//            t.assertEqual(1, singleCount)
-//            t.assertEqual(0, doubleCount)
-//          })
-//        }, 300)
-//      },
-//
-//      // should be fired if there are two taps within 250ms
-//      testDoubleTap: function(t){
-//        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
-//
-//        $('#test').on('singleTap', function(){
-//          singleCount++
-//        }).on('doubleTap', function(){
-//          doubleCount++
-//        })
-//
-//        down(element, 10, 10)
-//        up(element)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          down(element, 12, 12)
-//          up(element)
-//
-//          t.resume(function(){
-//            t.pause()
-//
-//            setTimeout(function(){
-//              t.resume(function(){
-//                t.assertEqual(0, singleCount)
-//                t.assertEqual(1, doubleCount)
-//              })
-//            }, 100)
-//          })
-//        }, 100)
-//      },
-//
-//      // should be fired if the finger is down in the same location for >750ms
-//      testLongTap: function(t){
-//        var count = 0, element = $('#test').get(0)
-//
-//        $('#test').on('longTap', function(){
-//          count++
-//        })
-//
-//        down(element, 10, 10)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          up(element)
-//
-//          t.resume(function(){
-//            t.assertEqual(1, count)
-//          })
-//        }, 900)
-//      },
-//
-//      testLongTapDoesNotFireIfFingerIsMoved: function(t){
-//        var count = 0, element = $('#test').get(0)
-//
-//        $('#test').on('longTap', function(){
-//          count++
-//        })
-//
-//        down(element, 10, 10)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          move(element, 50, 10)
-//          t.resume(function(){
-//            t.pause()
-//            setTimeout(function(){
-//              up(element)
-//              t.resume(function(){
-//                t.assertEqual(0, count)
-//              })
-//            }, 450)
-//          })
-//        }, 450)
-//      },
-//
-//      testSwipe: function(t){
-//        var swipeCount = 0, element = $('#test').get(0)
-//
-//        $('#test').on('swipe', function(){
-//          swipeCount++
-//        })
-//
-//        down(element, 10, 10)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          move(element, 70, 10)
-//          up(element)
-//
-//          t.resume(function(){
-//            t.pause()
-//
-//            setTimeout(function(){
-//              t.resume(function(){
-//                t.assertEqual(1, swipeCount)
-//              })
-//            }, 50)
-//          })
-//        }, 50)
-//      },
-//
-//      testTapDoNotFireWhenMoveToPointAndBack: function (t) {
-//        var tapCount = 0, element = $('#test').get(0)
-//
-//        $('#test').on('tap', function(){
-//          tapCount++
-//        })
-//        down(element, 10, 10)
-//        move(element, 60, 10)
-//
-//        t.pause()
-//        setTimeout(function(){
-//          t.resume(function(){
-//            move(element, 10, 10)
-//            up(element)
-//            t.pause()
-//            setTimeout(function(){
-//              t.resume( function () {
-//                t.assertEqual(0, tapCount)
-//              })
-//            }, 100)
-//          })
-//        }, 100)
-//      }
+      testScrollDoesNotFireTap: function(t){
+        var element = $('#test').get(0), count = 0
+
+        $('#test').on('tap', function () {
+          count++
+        })
+
+        down(element, 0, 0)
+        move(element, 0, 20)
+        move(element, 0, 20)
+        up(element)
+
+        t.pause()
+        setTimeout(function(){
+          t.resume(function(){
+            t.assertEqual(0, count)
+          })
+        }, 50)
+      },
+
+      testSingleTapDoesNotInterfereWithTappingTwice: function(t){
+        var count = 0, element = $('#test').get(0)
+
+        $('#test').on('tap', function(){
+          count++
+        })
+
+        down(element, 10, 10)
+        up(element)
+
+        t.pause()
+        setTimeout(function(){
+          down(element, 10, 10)
+          up(element)
+
+          t.resume(function(){
+            t.pause()
+
+            setTimeout(function(){
+              t.resume(function(){
+                t.assertEqual(2, count)
+              })
+            }, 200)
+          })
+        }, 200)
+      },
+
+      // should be fired if there is one tap within 250ms
+      testSingleTap: function(t){
+        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
+
+        $('#test').on('singleTap', function(){
+          singleCount++
+        }).on('doubleTap', function(){
+          doubleCount++
+        })
+
+        down(element, 10, 10)
+        up(element)
+
+        t.pause()
+        setTimeout(function(){
+          t.resume(function(){
+            t.assertEqual(1, singleCount)
+            t.assertEqual(0, doubleCount)
+          })
+        }, 300)
+      },
+
+      // should be fired if there are two taps within 250ms
+      testDoubleTap: function(t){
+        var singleCount = 0, doubleCount = 0, element = $('#test').get(0)
+
+        $('#test').on('singleTap', function(){
+          singleCount++
+        }).on('doubleTap', function(){
+          doubleCount++
+        })
+
+        down(element, 10, 10)
+        up(element)
+
+        t.pause()
+        setTimeout(function(){
+          down(element, 12, 12)
+          up(element)
+
+          t.resume(function(){
+            t.pause()
+
+            setTimeout(function(){
+              t.resume(function(){
+                t.assertEqual(0, singleCount)
+                t.assertEqual(1, doubleCount)
+              })
+            }, 100)
+          })
+        }, 100)
+      },
+
+      // should be fired if the finger is down in the same location for >750ms
+      testLongTap: function(t){
+        var count = 0, element = $('#test').get(0)
+
+        $('#test').on('longTap', function(){
+          count++
+        })
+
+        down(element, 10, 10)
+
+        t.pause()
+        setTimeout(function(){
+          up(element)
+
+          t.resume(function(){
+            t.assertEqual(1, count)
+          })
+        }, 900)
+      },
+
+      testLongTapDoesNotFireIfFingerIsMoved: function(t){
+        var count = 0, element = $('#test').get(0)
+
+        $('#test').on('longTap', function(){
+          count++
+        })
+
+        down(element, 10, 10)
+
+        t.pause()
+        setTimeout(function(){
+          move(element, 50, 10)
+          t.resume(function(){
+            t.pause()
+            setTimeout(function(){
+              up(element)
+              t.resume(function(){
+                t.assertEqual(0, count)
+              })
+            }, 450)
+          })
+        }, 450)
+      },
+
+      testSwipe: function(t){
+        var swipeCount = 0, element = $('#test').get(0)
+
+        $('#test').on('swipe', function(){
+          swipeCount++
+        })
+
+        down(element, 10, 10)
+
+        t.pause()
+        setTimeout(function(){
+          move(element, 70, 10)
+          up(element)
+
+          t.resume(function(){
+            t.pause()
+
+            setTimeout(function(){
+              t.resume(function(){
+                t.assertEqual(1, swipeCount)
+              })
+            }, 50)
+          })
+        }, 50)
+      },
+
+      testTapDoNotFireWhenMoveToPointAndBack: function (t) {
+        var tapCount = 0, element = $('#test').get(0)
+
+        $('#test').on('tap', function(){
+          tapCount++
+        })
+        down(element, 10, 10)
+        move(element, 60, 10)
+
+        t.pause()
+        setTimeout(function(){
+          t.resume(function(){
+            move(element, 10, 10)
+            up(element)
+            t.pause()
+            setTimeout(function(){
+              t.resume( function () {
+                t.assertEqual(0, tapCount)
+              })
+            }, 100)
+          })
+        }, 100)
+      }
 
       // TODO: test swipes in specific directions
     }
 
-//    Evidence('TouchTest',     $.extend({ emitEvent: emitTouchEvent }, tests))
-//    Evidence('MSPointerTest', $.extend({ emitEvent: emitMSPointerEvent }, tests))
+    Evidence('TouchTest',     $.extend({ emitEvent: emitTouchEvent }, tests))
+    Evidence('MSPointerTest', $.extend({ emitEvent: emitMSPointerEvent }, tests))
     Evidence('PointerTest',   $.extend({ emitEvent: emitPointerEvent }, tests))
   })()
   </script>


### PR DESCRIPTION
touch.js bind touch and pointer event at the same time, it will cause the event callback run twice in the browser which support both. 

![](https://img.alicdn.com/tps/TB1f8mRNFXXXXcDXVXXXXXXXXXX-744-836.png)

PS: chrome can enable pointer event from chrome://flags
