### PR TITLE
Compatible in webpack as an amd module

### DIFF
--- a/src/amd_layout.js
+++ b/src/amd_layout.js
@@ -3,7 +3,7 @@
     define(function() { return factory(global) })
   else
     factory(global)
-}(this, function(window) {
+}(typeof window !== 'undefined' ? window : this, function(window) {
   YIELD
   return Zepto
 }))


### PR DESCRIPTION
In webpack this module like this:

``` javascript
// webpack module
/* 2 */
/***/ function(module, exports, __webpack_require__) {

    var __WEBPACK_AMD_DEFINE_RESULT__;/* Zepto v1.2.0 - zepto event ajax form ie - zeptojs.com/license */
    (function(global, factory) {
      console.log(global);
      if (true)
        !(__WEBPACK_AMD_DEFINE_RESULT__ = function() { return factory(global) }.call(exports, __webpack_require__, exports, module), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__))
      else
        factory(global)
    }(this, function(window) {

    // Zepto
  });
}
```

then `this` will be lost and isn't equal to `window`, maybe `typeof window !== "undefined" ? window : this` is a good solution
