### PR TITLE
add the leading semicolon of the IIFE in amd_layout.js.

### DIFF
--- a/src/amd_layout.js
+++ b/src/amd_layout.js
@@ -1,4 +1,4 @@
-(function(global, factory) {
+;(function(global, factory) {
   if (typeof define === 'function' && define.amd)
     define(function() { return factory(global) })
   else


### PR DESCRIPTION
No leading semicolon in amd_layout.js file will cause:
```
Uncaught TypeError: (intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(intermediate value)(...) is not a function
```
![zepto](https://cloud.githubusercontent.com/assets/3142886/19517923/a1e1096e-9636-11e6-8c40-2e80dab00e3b.png)
