### PR TITLE
remove redundancy codes in zepto.init

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -719,7 +719,7 @@ var Zepto = (function() {
           var props = {}
           var computedStyle = getComputedStyle(element, '')
           $.each(property, function(_, prop){
-            props[prop] = (element.style[camelize(prop)] || computedStyle.getPropertyValue(prop))
+            props[prop] = (element.style[camelize(prop)] || computedStyle.getPropertyValue(dasherize(prop)))
           })
           return props
         }

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -212,9 +212,6 @@ var Zepto = (function() {
       // Wrap DOM nodes.
       else if (isObject(selector))
         dom = [selector], selector = null
-      // If it's a html fragment, create nodes from it
-      else if (fragmentRE.test(selector))
-        dom = zepto.fragment(selector.trim(), RegExp.$1, context), selector = null
       // If there's a context, create a collection on that context first, and select
       // nodes from there
       else if (context !== undefined) return $(context).find(selector)

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -713,7 +713,7 @@ var Zepto = (function() {
         var element = this[0]
         if (typeof property == 'string') {
           if (!element) return
-          return element.style[camelize(property)] || getComputedStyle(element, '').getPropertyValue(property)
+          return element.style[camelize(property)] || getComputedStyle(element, '').getPropertyValue(dasherize(property))
         } else if (isArray(property)) {
           if (!element) return
           var props = {}

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1672,6 +1672,20 @@
         t.assertEqual('rgb(0, 0, 0)', div.css('color'))
       },
 
+      testCamelizeCSSQuery:function(t){
+        var el=$('#some_element'),
+            dom=el.get(0)
+        t.assertEqual(el.css('background-color'),el.css('backgroundColor'))
+        t.assertEqual(el.css('borderRadius'),el.css('border-radius'))
+        t.assertEqual(el.css('background-position-x'),el.css('backgroundPositionX'))
+        t.assertEqual(el.css('color'),getComputedStyle(dom,null).getPropertyValue('color'))
+
+        el.css('backgroundColor', 'rgba(100,100,100,.5)')
+
+        t.assertEqual(el.css('background-color'),el.css('backgroundColor'))
+        t.assertEqual(el.css('backgroundColor'),getComputedStyle(dom,null).getPropertyValue('background-color'))
+      },
+
       testCSSUnset: function (t) {
         var el = $('#some_element').css({ 'margin-top': '1px', 'margin-bottom': '1px' }),
             dom = el.get(0)

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1672,13 +1672,28 @@
         t.assertEqual('rgb(0, 0, 0)', div.css('color'))
       },
 
-      testCamelizeCSSQuery:function(t){
+      testCamelizeQueryByComputedStyle:function(t){
         var el=$('#some_element'),
             dom=el.get(0)
         t.assertEqual(el.css('background-color'),el.css('backgroundColor'))
         t.assertEqual(el.css('borderRadius'),el.css('border-radius'))
         t.assertEqual(el.css('background-position-x'),el.css('backgroundPositionX'))
         t.assertEqual(el.css('color'),getComputedStyle(dom,null).getPropertyValue('color'))
+         
+        //query style by a array
+        var styleMap,styleMapWithCamelize,styleArr,styleArrWithCamelize,len,i
+
+        el.css('borderLeftWidth', '5px')
+        
+        styleMap=el.css(['background-repeat','background-clip','font-size','border-left-width'])
+        styleMapWithCamelize=el.css(['backgroundRepeat','backgroundClip','fontSize','borderLeftWidth'])
+        styleArr=['background-repeat','background-clip','font-size','border-left-width']
+        styleArrWithCamelize=['backgroundRepeat','backgroundClip','fontSize','borderLeftWidth']
+        len=styleArr.length
+   
+        for (i = 0; i < len; i++) {
+          t.assertEqual(styleMap[styleArr[i]],styleMapWithCamelize[styleArrWithCamelize[i]])
+        }
 
         el.css('backgroundColor', 'rgba(100,100,100,.5)')
 


### PR DESCRIPTION
In function which called zepto.init,some codes is redundancy.That codes never be executed,the codes of create DOM fragment has written above codes that I deleted.Thanks!
