### PR TITLE
More reliable way to examine DOM readiness on IE

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -25,7 +25,6 @@ var Zepto = (function() {
       'td': tableRow, 'th': tableRow,
       '*': document.createElement('div')
     },
-    readyRE = /complete|loaded|interactive/,
     simpleSelectorRE = /^[\w-]*$/,
     class2type = {},
     toString = class2type.toString,
@@ -437,10 +436,12 @@ var Zepto = (function() {
     },
 
     ready: function(callback){
-      // need to check if document.body exists for IE as that browser reports
-      // document ready when it hasn't yet created the body element
-      if (readyRE.test(document.readyState) && document.body) callback($)
-      else document.addEventListener('DOMContentLoaded', function(){ callback($) }, false)
+      // don't use "interactive" on IE <= 10 (it can fired premature)
+      if (document.readyState === "complete" ||
+          (document.readyState !== "loading" && !document.documentElement.doScroll))
+        callback($)
+      else
+        document.addEventListener("DOMContentLoaded", function(){ callback($) }, false)
       return this
     },
     get: function(idx){

--- a/src/zepto.js
+++ b/src/zepto.js
@@ -439,7 +439,7 @@ var Zepto = (function() {
       // don't use "interactive" on IE <= 10 (it can fired premature)
       if (document.readyState === "complete" ||
           (document.readyState !== "loading" && !document.documentElement.doScroll))
-        callback($)
+        setTimeout(function(){ callback($) }, 0)
       else
         document.addEventListener("DOMContentLoaded", function(){ callback($) }, false)
       return this

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -2649,8 +2649,10 @@
       },
 
       testDocumentReady: function (t) {
-        // Check that if document is already loaded, ready() immediately executes callback
-        var arg1, arg2, arg3, arg4, fired = false
+        // Check that ready() callback fired and get Zepto as an argument
+        var arg1, arg2, arg3, arg4
+
+        t.pause()
         $(function (Z1) {
           arg1 = Z1
           $(document).ready(function (Z2) {
@@ -2659,16 +2661,16 @@
               arg3 = Z3
               $(document).on('foo ready bar', function (Z4) {
                 arg4 = Z4
-                fired = true
+                t.resume(function(){
+                  t.assertIdentical(Zepto, arg1)
+                  t.assertIdentical(Zepto, arg2)
+                  t.assertIdentical(Zepto, arg3)
+                  t.assertIdentical(Zepto, arg4)
+                })
               })
             })
           })
         })
-        t.assertTrue(fired)
-        t.assertIdentical(Zepto, arg1)
-        t.assertIdentical(Zepto, arg2)
-        t.assertIdentical(Zepto, arg3)
-        t.assertIdentical(Zepto, arg4)
       },
 
       testSlice: function (t) {


### PR DESCRIPTION
This commit is revisiting of the following commit.

commit 790d6c29f108777f4420b25ea6894e3f3028ca85
Author: sgtwilko null@sgtwilko.f9.co.uk
Date:   Wed Oct 2 10:47:09 2013 +0100

```
Ready fires on IE10 before the document is ready.

Added additional check for document.body into the ready check.
Changing the readyRE regex does resolve the issue on IE, but breaks
Chrome.  Adding this check fixes IE and doesn't seem to have any
problems on Chrome/Firefox.
```

More info about the original problem with IE can be found in related
jQuery tracker [1](https://bugs.jquery.com/ticket/12282).

This commit solves the particular case when IE <= 10 gives non-null
`document.body` in "interactive" `document.readyState`, but DOM isn't
fully parsed at the moment. The case was catched in [2](https://bugs.jquery.com/ticket/12282#comment:20). This commit
adapt current jQuery's approach to detect IE9 & IE 10, see [3](https://github.com/jquery/jquery/pull/2678).

Related zepto trackers: #733, #916.
## Build size

Calculated for a build with the default modules set:

```
zepto.js      58760 -> 58726 ( +6 bytes)
zepto.min.js  26411 -> 26427 (+16 bytes)
zepto.min.gz   9804 ->  9799 ( -5 bytes)
```
