### PR TITLE
Fix ready() on IE (again)

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -436,12 +436,16 @@ var Zepto = (function() {
     },
 
     ready: function(callback){
-      // don't use "interactive" on IE <= 10 (it can fired premature)
+      // don't use "interactive" and "DOMContentLoaded" on IE <= 10 (it can fired premature)
+      var oldIE = !!document.documentElement.doScroll
+      var invokeCallback = function(){ callback($) }
       if (document.readyState === "complete" ||
-          (document.readyState !== "loading" && !document.documentElement.doScroll))
-        setTimeout(function(){ callback($) }, 0)
+          (document.readyState !== "loading" && !oldIE))
+        setTimeout(invokeCallback, 0)
+      else if (!oldIE)
+        document.addEventListener("DOMContentLoaded", invokeCallback, false)
       else
-        document.addEventListener("DOMContentLoaded", function(){ callback($) }, false)
+        window.addEventListener("load", invokeCallback, false)
       return this
     },
     get: function(idx){


### PR DESCRIPTION
We shouldn't use "DOMContentLoaded" event on IE10 as well as
"interactive" state. This commit is continuation of effort in PR #1235
and hopefully now it really fixed for any configuration.

With my server configuration (async script loading) ready() works on
IE9, but doesn't work on IE10 from time to time. I found that ready()
doesn't call the callback when invoked in "interactive" state. That
means the moment when "DOMContentLoaded" very likely was already fired.
In this case the callback won't invoked at all.

Current implementation can be explained in very simple words. We invoke
the callback when:

* (old IE) in "complete" state or when "load" event occurs;
* (others) in "interactive" state or when "DOMContentLoaded" event
  occurs.

The change tested with Microsoft's VM images from [1] on IE9 and IE10.
Seems to be good.

[1]: https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/

Build size
----------

Calculated for a build with the default modules set:

```
zepto.js      58755 -> 58921 (+166 bytes)
zepto.min.js  26453 -> 26486 ( +33 bytes)
zepto.min.gz   9806 ->  9824 ( +18 bytes)
```

Note: Size of zgipped version is little flaky as depends on the first
line (comment) with a commit id, so don't worry if it differs on +/- 5
bytes from my numbers.