### PR TITLE
Explicitly use window

### DIFF
--- a/src/amd_layout.js
+++ b/src/amd_layout.js
@@ -3,7 +3,7 @@
     define(function() { return factory(global) })
   else
     factory(global)
-}(this, function(window) {
+}(window, function(window) {
   YIELD
   return Zepto
 }))


### PR DESCRIPTION
This fixes an issue when using zepto with Browserify. To prevent scope leakage, browserify wraps modules in a function. `this` becomes the scope of that function, and not `window`.

Will solve:

- https://github.com/madrobby/zepto/issues/1222
- https://github.com/madrobby/zepto/issues/1210