### PR TITLE
Deprecate event.data in favour of event.customData

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -47,7 +47,7 @@
     return hover[type] || (focusinSupported && focus[type]) || type
   }
 
-  function add(element, events, fn, data, selector, delegator, capture){
+  function add(element, events, fn, customData, selector, delegator, capture){
     var id = zid(element), set = (handlers[id] || (handlers[id] = []))
     events.split(/\s/).forEach(function(event){
       if (event == 'ready') return $(document).ready(fn)
@@ -65,7 +65,7 @@
       handler.proxy = function(e){
         e = compatible(e)
         if (e.isImmediatePropagationStopped()) return
-        e.data = data
+        e.customData = customData
         var result = callback.apply(element, e._args == undefined ? [e] : [e].concat(e._args))
         if (result === false) e.preventDefault(), e.stopPropagation()
         return result

--- a/test/event.html
+++ b/test/event.html
@@ -142,7 +142,7 @@
 
       testOneWithData: function(t){
         var obj = {}, gotObj, count = 0
-        $(document).one('click', obj, function(e){ gotObj = e.data; count++ })
+        $(document).one('click', obj, function(e){ gotObj = e.customData; count++ })
 
         click(this.el)
         click(this.el)
@@ -168,7 +168,7 @@
       },
 
       testOnWithBlankData: function(t){
-        var log = [], fn = function(e){ log.push(e.data) }
+        var log = [], fn = function(e){ log.push(e.customData) }
         this.el
           .on('click', null, fn)
           .on('click', undefined, fn)
@@ -262,7 +262,7 @@
         var gotData
 
         $(document).on('click', function(event){
-          gotData = event.data
+          gotData = event.customData
         })
         t.assertUndefined(gotData)
 
@@ -274,7 +274,7 @@
         var data = {}, gotData, numArgs
 
         $(document).on('click', data, function(event){
-          gotData = event.data
+          gotData = event.customData
           numArgs = arguments.length
         })
         t.assertUndefined(gotData)
@@ -283,13 +283,13 @@
         t.assertEqual(1, numArgs)
         t.assertIdentical(data, gotData)
       },
-      
+
       testHandlerWithFunctionAsData: function(t){
         var data = function () { console.log('foo') },
             gotData, numArgs
-        
+
         $(document).on('click', data, function(event){
-          gotData = event.data
+          gotData = event.customData
           numArgs = arguments.length
         })
         t.assertUndefined(gotData)
@@ -303,7 +303,7 @@
         var data = {}, gotData, numArgs
 
         $(document).on('click', 'div', data, function(event){
-          gotData = event.data
+          gotData = event.customData
           numArgs = arguments.length
         })
         t.assertUndefined(gotData)
@@ -317,7 +317,7 @@
         var data = {}, gotData
 
         $(document).on('myevent', data, function(event){
-          gotData = event.data
+          gotData = event.customData
         })
         t.assertUndefined(gotData)
 


### PR DESCRIPTION
Fixes: https://github.com/madrobby/zepto/issues/1256.

Recent versions of Chrome and Firefox include a new event type `InputEvent` which exposes an attribute `.data` that is readonly. https://developer.mozilla.org/en-US/docs/Web/API/InputEvent

Step to reproduce on Firefox or latest chrome with the Experimental Web `Platform features` `chrome://flags`

```
(function(){
  "use strict"
  var e = new InputEvent("test");
  e.data = "boom";
})()
VM275:4 Uncaught TypeError: Cannot assign to read only property 'data' of object '#<InputEvent>'
    at <anonymous>:4:10
    at <anonymous>:5:3
```

Proposed solution: deprecate the field `.data` and replace it with a `.customData`. 

Any thoughts?