### PR TITLE
Added support for passing nodes in $.is()

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -480,7 +480,8 @@ var Zepto = (function() {
       return $(uniq(this.concat($(selector,context))))
     },
     is: function(selector){
-      return this.length > 0 && zepto.matches(this[0], selector)
+      return typeof selector == 'string' ? this.length > 0 && zepto.matches(this[0], selector) : 
+          selector && this.selector == selector.selector
     },
     not: function(selector){
       var nodes=[]

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1590,9 +1590,12 @@
         t.assert($('#li2').is(':first-child'))
         t.assert(!$('#find1').is('doesnotexist'))
         t.assert(!$('#find1').is())
+        t.assert($('#find1').is($('#find1')))
+        t.assert(!$('#find1').is($('#find2')))
 
         t.assert($('#fixtures div').is('#some_element'))
         t.assert(!$('#doesnotexist').is('p'))
+        t.assert(!$('#doesnotexist').is($('#find1')))
 
         t.assert(!$(window).is('p'))
       },


### PR DESCRIPTION
As discussed in issue #1242 passing nodes in $.is() is used within Bootstrap.

This PR adds support for those use cases