### PR TITLE
Add object form to prop method

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -664,11 +664,12 @@ var Zepto = (function() {
     },
     prop: function(name, value){
       name = propMap[name] || name
-      return (1 in arguments) ?
+      return (typeof name == 'string' && !(1 in arguments)) ?
+        (this[0] && this[0][name]) :
         this.each(function(idx){
-          this[name] = funcArg(this, value, idx, this[name])
-        }) :
-        (this[0] && this[0][name])
+          if (isObject(name)) for (key in name) this[key] = name[key]
+          else this[name] = funcArg(this, value, idx, this[name])
+        })
     },
     removeProp: function(name){
       name = propMap[name] || name

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -81,6 +81,7 @@
   <map name="imgMap">
   </map>
   <div id="prop_test7" contenteditable="true"></div>
+  <input id="prop_test8" type="checkbox" checked />
 
   <div class="htmltest" id="htmltest1"></div>
   <div class="htmltest" id="htmltest2"></div>
@@ -1861,6 +1862,7 @@
         var td2 = $('#prop_test5')
         var img = $('#prop_test6')
         var div = $('#prop_test7')
+        var checkbox = $('#prop_test8')
 
         t.assertEqual(input.prop('tabindex'), -1)
         t.assertEqual(input.prop('readonly'), true)
@@ -1873,6 +1875,10 @@
         t.assertEqual(td2.prop('colspan'), 2)
         t.assertEqual(img.prop('usemap'), '#imgMap')
         t.assertEqual(div.prop('contenteditable'), 'true')
+
+        checkbox.prop({'checked': false, 'disabled': true})
+        t.assertEqual(checkbox.prop('checked'), false)
+        t.assertEqual(checkbox.prop('disabled'), true)
       },
 
       testRemoveProp: function(t){


### PR DESCRIPTION
This form, which accepts an object of property-value pairs, has been
present in jQuery since 1.6 ([http://api.jquery.com/prop/#prop-properties](http://api.jquery.com/prop/#prop-properties)).

I also flipped the logic of the ternary operator so that it parallels the `attr` method.