### PR TITLE
Fix object form of prop method: translate names

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -668,7 +668,7 @@ var Zepto = (function() {
       return (typeof name == 'string' && !(1 in arguments)) ?
         (this[0] && this[0][name]) :
         this.each(function(idx){
-          if (isObject(name)) for (key in name) this[key] = name[key]
+          if (isObject(name)) for (key in name) this[propMap[key] || key] = name[key]
           else this[name] = funcArg(this, value, idx, this[name])
         })
     },

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -1879,7 +1879,8 @@
         t.assertEqual(img.prop('usemap'), '#imgMap')
         t.assertEqual(div.prop('contenteditable'), 'true')
 
-        checkbox.prop({'checked': false, 'disabled': true})
+        checkbox.prop({'class': 'propTest', 'checked': false, 'disabled': true})
+        t.assertEqual(checkbox.prop('class'), 'propTest')
         t.assertEqual(checkbox.prop('checked'), false)
         t.assertEqual(checkbox.prop('disabled'), true)
       },


### PR DESCRIPTION
I messed up with PR #1300 - short/lowercase property names like class, readonly, etc. were not being translated in the new object form of the `prop` method. This patch fixes it.