### PR TITLE
Fix attr() getter for boolean attributes

### DIFF
--- a/src/zepto.js
+++ b/src/zepto.js
@@ -31,6 +31,7 @@ var Zepto = (function() {
     zepto = {},
     camelize, uniq,
     tempParent = document.createElement('div'),
+    boolAttrRE = /^allowfullscreen|allowpaymentrequest|allowusermedia|async|autofocus|autoplay|checked|controls|default|defer|disabled|formnovalidate|hidden|ismap|itemscope|loop|multiple|muted|nomodule|novalidate|open|playsinline|readonly|required|reversed|selected|typemustmatch$/i,
     propMap = {
       'tabindex': 'tabIndex',
       'readonly': 'readOnly',
@@ -292,6 +293,11 @@ var Zepto = (function() {
 
   function funcArg(context, arg, idx, payload) {
     return isFunction(arg) ? arg.call(context, idx, payload) : arg
+  }
+
+  function getAttribute(node, name) {
+    if (boolAttrRE.test(name)) return node.getAttribute(name) != null ? name.toLowerCase() : undefined
+    else return (result = node.getAttribute(name)) != null ? result : undefined
   }
 
   function setAttribute(node, name, value) {
@@ -651,11 +657,11 @@ var Zepto = (function() {
     attr: function(name, value){
       var result
       return (typeof name == 'string' && !(1 in arguments)) ?
-        (0 in this && this[0].nodeType == 1 && (result = this[0].getAttribute(name)) != null ? result : undefined) :
+        (0 in this && this[0].nodeType == 1 ? getAttribute(this[0], name) : undefined) :
         this.each(function(idx){
           if (this.nodeType !== 1) return
           if (isObject(name)) for (key in name) setAttribute(this, key, name[key])
-          else setAttribute(this, name, funcArg(this, value, idx, this.getAttribute(name)))
+          else setAttribute(this, name, funcArg(this, value, idx, getAttribute(this, name)))
         })
     },
     removeAttr: function(name){

--- a/test/zepto.html
+++ b/test/zepto.html
@@ -58,6 +58,8 @@
   <div id="attr_remove_multi" data-id="someId1" data-name="someName1"></div>
   <form><input id="attr_val" value="Hello World"></form>
 
+  <input id="attr_bool" required />
+
   <div id="data_attr" data-foo="bar" data-foo-bar="baz" data-empty></div>
 
   <form id="attr_with_text_input">
@@ -204,8 +206,6 @@
   <div id="another_element"></div>
 
   <div id="namespace_test"></div>
-
-  <input type="text" id="BooleanInput" required />
 
   <form id="some_form"></form>
 
@@ -1850,6 +1850,12 @@
         t.assertEqual('1id', $('#attr_2').attr('data-id'))
       },
 
+      testBoolAttr: function (t) {
+        var el = $('#attr_bool')
+        t.assertEqual('required', el.attr('required'))
+        t.assertUndefined(el.attr('disabled'))
+      },
+
       testAttrSetterErase: function(t){
         var el = $('<div data-name="foo">')
         t.assertIdentical(el, el.attr('data-name', undefined), 'setter should return self')
@@ -2650,12 +2656,6 @@
         t.assertEqual($("span").index("boo"), -1)
 
         t.assertEqual($('#index_test > *').eq(-1).index(), 1)
-      },
-
-      testBoolAttr: function (t) {
-        var el = $('#BooleanInput')
-        t.assertEqual('', el.attr('required'))
-        t.assertUndefined(el.attr('non_existant_attr'))
       },
 
       testDocumentReady: function (t) {


### PR DESCRIPTION
If a boolean attribute is present, regardless of value, return the lowercase attribute name. This is what jQuery does.

List of boolean attributes was obtained from [html.spec.whatwg.org/multipage/indices.html#attributes-3](html.spec.whatwg.org/multipage/indices.html#attributes-3)

Fixes #1304 