### PR TITLE
[Event] fix RegExp for namespace matching

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -34,7 +34,7 @@
     return {e: parts[0], ns: parts.slice(1).sort().join(' ')}
   }
   function matcherFor(ns) {
-    return new RegExp('(?:^| )' + ns.replace(' ', ' .* ?') + '(?: |$)')
+    return new RegExp('(?:^| )' + ns.replace(/\s{1}/g, ' .* ?') + '(?: |$)')
   }
 
   function eventCapture(handler, captureSetting) {

--- a/src/event.js
+++ b/src/event.js
@@ -34,7 +34,7 @@
     return {e: parts[0], ns: parts.slice(1).sort().join(' ')}
   }
   function matcherFor(ns) {
-    return new RegExp('(?:^| )' + ns.replace(/\s{1}/g, ' .* ?') + '(?: |$)')
+    return new RegExp('(?:^| )' + ns.replace(/ /g, ' .* ?') + '(?: |$)')
   }
 
   function eventCapture(handler, captureSetting) {


### PR DESCRIPTION
`String.prototype.replace()` replaces only the first match, it may need an global RegExp to match all the spaces. Otherwise event type with namespace like `click.nsA.nsC.nsE` can not be matched with `click.nsA.nsC.nsD.nsE` etc.