### PR TITLE
Update .npmignore to include files for building zepto

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,4 +4,4 @@
 !dist/zepto.js
 !dist/zepto.min.js
 !src/*.js
-src/amd_layout.js
+!make


### PR DESCRIPTION
Currently the npm package can't be used to build zepto because it doesn't include the `make` and `src/amd_layout.js` files. Steps to reproduce:

    $ npm install zepto

    $ cd node_modules/zepto

    $ npm install # dev/build dependencies

    $ ./node_modules/coffee-script/bin/coffee make dist

Being able to install and build via npm is useful for projects that use npm/yarn to manage dependencies. Including the `make` and `src/amd_layout.js` files makes it work.