### PR TITLE
add support for :input selector

### DIFF
--- a/src/selector.js
+++ b/src/selector.js
@@ -26,6 +26,7 @@
     hidden:   function(){ if (!visible(this)) return this },
     selected: function(){ if (this.selected) return this },
     checked:  function(){ if (this.checked) return this },
+    input:    function(){ if (('disabled' in this) || this.contentEditable === 'true') return this },
     parent:   function(){ return this.parentNode },
     first:    function(idx){ if (idx === 0) return this },
     last:     function(idx, nodes){ if (idx === nodes.length - 1) return this },

--- a/test/selector.html
+++ b/test/selector.html
@@ -20,6 +20,7 @@
     <ul id=list><li>one</li><li>two</li></ul>
     <div class=visibility id=vis>look at me!</div>
     <div class=visibility id=invis style="display:none">can't see me</div>
+    <input type=text id=in />
     <ol id=child class=test>
       <li><span>child1</span></li>
       <li><span>child2</span>
@@ -56,6 +57,9 @@
       testVisibility: function(t) {
         t.assertEqual('vis', $('.visibility:visible').attr('id'))
         t.assertEqual('invis', $('.visibility:hidden').attr('id'))
+      },
+      testInput: function(t) {
+        t.assertEqual('in', $('#in:input').attr('id'))
       },
       testIs: function(t) {
         t.assert($('#list').is('ul'))


### PR DESCRIPTION
Add support for the `:input` pseudo-selector to selector.js. This is a very small change that will have a big impact on jQuery plugin compatibility (for any form-related plugin).

NOTE: I'd be willing to drop the check for `contentEditable` as that's not a very common way to identify an input.

See https://api.jquery.com/input-selector/ for reference.