### PR TITLE
Ignore HTML for zepto repository languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false


### PR DESCRIPTION
This is a JavaScript project library, ignoring the directory `examples` HTML can be really useful for search engines like GitHub search. hope this makes sense!
![ScreenShot_20201029163210](https://user-images.githubusercontent.com/49124992/97596223-c9a29980-1a04-11eb-8a36-81d030de61b8.png)
